### PR TITLE
contenteditable and arrow keys

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -135,7 +135,7 @@ var Reveal = (function(){
 	 */
 	function onDocumentKeyDown( event ) {
 		
-		if( event.keyCode >= 37 && event.keyCode <= 40 ) {
+		if( event.keyCode >= 37 && event.keyCode <= 40 && event.target.contentEditable === 'inherit' ) {
 			
 			switch( event.keyCode ) {
 				case 37: navigateLeft(); break; // left


### PR DESCRIPTION
I was putting together a little ditty and I used a contenteditable code block. The plan was to edit code on the fly, but when I hit the arrow key it changed slides (arg!)

So I put in a quick check for contenteditable. if it is inherit, do the transition, otherwise its editable and don't do it.

Works in Chrome and FF8.
