### PR TITLE
Mouse scroll handling 

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -173,6 +173,11 @@ var Reveal = (function(){
 			// Add some 3D magic to our anchors
 			linkify();
 		}
+		
+		//bind scrolling
+		 if(window.addEventListener){
+		    document.addEventListener('DOMMouseScroll', scrollStep, false);
+		    }
 
 		// Read the initial hash
 		readURL();
@@ -675,6 +680,26 @@ var Reveal = (function(){
 			slide();
 		}
 	}
+	
+	var stepT=0;
+  function scrollStep(e){
+  clearTimeout(stepT);
+  stepT=setTimeout(function(){
+      if(e.detail>0){
+        if(availableRoutes().down){
+          navigateDown()
+          }else{
+          navigateRight()
+          }
+        }else{
+        if(availableRoutes().up){
+          navigateUp()
+          }else{
+          navigateLeft()
+          }
+        }
+      },200);
+    }
 	
 	// Expose some methods publicly
 	return {


### PR DESCRIPTION
I devised a simple algorithm that goes to the next slide despite the required direction. Slides can be switched easily with mouse scroll, which is much more handy than trying to click the navigation arrows. I am a wireless mouse user ;)

Also - scroll event is throttled to prevent problems with carefully scrolling just a single slide.

This is on by default, you could make it optional quite easily.

And BTW, thanks for your work. Really helpful
