### PR TITLE
Overview mode shows hidden fragments. Issue #30.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -856,6 +856,9 @@ html {
 	cursor: pointer;
 	background: rgba(0,0,0,0.1);
 }
+#reveal.overview .slides section .fragment {
+    opacity: 1;
+}
 #reveal.overview .slides section:after,
 #reveal.overview .slides section:before {
 	display: none !important;


### PR DESCRIPTION
I added and verified CSS to show hidden fragments in overview mode. I tested in Firefox 10.0.2 and Chrome 18.0.1025.162 m.
I made this feature request in issue #30.

On another note, reveal.js was a major hit for my bioinformatics presentation and I think a few of the CS students in the audience will be using reveal for their presentations as well.

http://www.philipbjorge.com/bioinformatics-presentation/
