### PR TITLE
New key mappings

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -156,7 +156,7 @@ var Reveal = (function(){
 		// instead of checking contentEditable?
 
 		if ( event.target.contentEditable != 'inherit' ||
-			event.shiftKey || event.altKey || event.ctrlKey ) return;
+			event.shiftKey || event.altKey || event.ctrlKey || event.metaKey ) return;
 				
 		var triggered = false;
 		switch( event.keyCode ) {


### PR DESCRIPTION
This patch adds:

hjkl for directions.
space and n for next slide, p for previous slide
esc for 3D overview (instead of space)

Rationale:
I think space is the most intuitive way to iterate through slides (as with PgDn, traverses down and right as appropriate) without even needing to provide any instructions. As many laptops don't have PgUp/PgDn, it's also necessary to provide a mapping for Previous, which is why I added "p" and therefore "n" for consistency.

I'd argue esc is more appropriate than space for the context-shift of the 3D overview.

Added vim bindings because they're convenient, some devices might not support arrow keys, and they're being used in Twitter and Google+ among other websites.
