### PR TITLE
Add the possibility to register a callback for slide changes

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -491,6 +491,11 @@ var Reveal = (function(){
 		indexh = updateSlides( HORIZONTAL_SLIDES_SELECTOR, indexh );
 		indexv = updateSlides( VERTICAL_SLIDES_SELECTOR, indexv );
 
+		// call onSlideChange if someone registered that function
+		if (typeof Reveal.onSlideChange === "function") {
+			Reveal.onSlideChange(indexh, indexv);
+		}
+
 		// Apply the new state
 		stateLoop: for( var i = 0, len = state.length; i < len; i++ ) {
 			// Check if this state existed on the previous slide. If it 


### PR DESCRIPTION
Add the possibility to register a callback with Reveal.onSlideChange = funnction(indexh, indexv){} which get's called on each slideChange.

This would - for example - make it possible to synchronize/share the presentation between multiple browser instances.
An example with faye/websockets:
On the "master"-presentation of the speaker:
Reveal.onSlideChange = function(indexh, indexv) {
   faye.publish("/reveal/navigateTo", {indexh: indexh, indexv: indexv});
}

On the "slave"-presentations of the attendees:
faye.subscribe("/reveal/navigateTo", function(slide){
    Reveal.navigateTo(slide.indexh, slide.indexv);
});

Another approach to enable something like this could be to expose a function like Reveal.addEventListener("slideChange", function(...){});
