### PR TITLE
adds charset declaration in main.css

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * Main styles for reveal.js 
  *


### PR DESCRIPTION
There are unicode characters on the styles for `.reveal q:before` and `.reveal q:after`. Best to declare the charset on the top of the CSS file if you want to prevent charset issues.
