### PR TITLE
slidechange doesn't get fired on "hashchange" events

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -765,12 +765,12 @@ var Reveal = (function(){
 	function readURL() {
 		// Break the hash down to separate components
 		var bits = window.location.hash.slice(2).split('/');
-		
+
 		// Read the index components of the hash
-		indexh = parseInt( bits[0] ) || 0 ;
-		indexv = parseInt( bits[1] ) || 0 ;
-		
-		navigateTo( indexh, indexv );
+		var h = parseInt( bits[0] ) || 0 ;
+		var v = parseInt( bits[1] ) || 0 ;
+
+		navigateTo( h, v );
 	}
 	
 	/**


### PR DESCRIPTION
Setting `indexh` and `indexv` in `readURL()` (which is called at startup and when "onchangehash" is fired) prevents firing of "slidechanged" at startup and when you make use of internal links between slides. What I can see is that scripts/plugins that are listening on "slidechanged" to update a certain state aren't notified. A plugin like @rmurphey's presenter-notes-server for example  wouldn't get notified and wouldn't be able to update the presenter-window.
