### PR TITLE
Increase line-height for links to allow for descenders

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -313,6 +313,7 @@ body {
 
 .reveal .roll {
     display: inline-block;
+    line-height: 1.2;
     overflow: hidden;
 
     vertical-align: top;


### PR DESCRIPTION
Previously, descenders from characters like 'g' or 'y' were truncated (overflow: hidden)
