### PR TITLE
Ensure images are bound within the section

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -108,6 +108,12 @@ body {
 	font-weight: normal;
 }
 
+.reveal img {
+	/* preserve aspect ratio and scale image so it's bound within the section */
+	max-width: 100%;
+	max-height: 100%;
+} 
+
 .reveal strong, 
 .reveal b {
 	font-weight: bold;


### PR DESCRIPTION
Previously, images would overflow the section. Proposing a simple solution to scale them so they fit in the section, while preserving aspect ratio.
