### PR TITLE
Open notes in new window, instead of printing to console

### DIFF
--- a/plugin/speakernotes/client.js
+++ b/plugin/speakernotes/client.js
@@ -5,7 +5,7 @@
 	var socket = io.connect(window.location.origin);
 	var socketId = Math.random().toString().slice(2);
 	
-	console.log('View slide notes at ' + window.location.origin + '/notes/' + socketId);
+        window.open(window.location.origin + '/notes/' + socketId, 'notes-' + socketId)
 
 	Reveal.addEventListener( 'slidechanged', function( event ) {
 		var nextindexh;


### PR DESCRIPTION
It can be tedious to load up the speaker notes, with the whole having to
open the javascript console, and clicking on the link.

This simplifies it by automatically opening the notes in a new window.
Most browsers will warn that it's trying to open a pop-up, but it's easy
enough to allow it.
