### PR TITLE
PDF CSS tweaks to match browser rendering more closely

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -15,7 +15,7 @@
 }
 
 body {
-	font-size: 22pt;
+	font-size: 18pt;
 	width: auto;
 	height: auto;
 	border: 0;
@@ -46,8 +46,8 @@ html {
 
 /* SECTION 3: Set body font face, size, and color.
    Consider using a serif font for readability. */
-body, p, td, li, div, a {
-	font-size: 22pt;
+body, p, td, li, div {
+	font-size: 18pt;
 }
 
 /* SECTION 4: Set heading font face, sizes, and color.
@@ -155,4 +155,8 @@ ul, ol, div, p {
 
 .reveal small a {
 	font-size: 16pt !important;
+}
+
+pre {
+    font-size: 9pt !important;
 }


### PR DESCRIPTION
font-size: 18pt; instead of fount-size: 22pt;
  remove the "a" tag from def that forces font size, otherwise anchors in various contexts, e.g., headings, etc., will cause ugly rendering due to mismatched font size.
   specify font size for "pre" tags so that code listings more closely match browser rendering
