### PR TITLE
new transition style: 'none' that has no transition animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Reveal.initialize({
 	rollingLinks: true,
 
 	// Transition style
-	transition: 'default' // default/cube/page/concave/linear(2d)
+	transition: 'default' // default/cube/page/concave/linear(2d)/none
 });
 ```
 

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -537,6 +537,52 @@ body {
 	        transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0);
 }
 
+/*********************************************
+ * NO TRANSITION ('none')
+ *********************************************/
+
+.reveal.none .slides>section.past {
+	-webkit-transform: translate(0, 0);
+	   -moz-transform: translate(0, 0);
+	    -ms-transform: translate(0, 0);
+	     -o-transform: translate(0, 0);
+	        transform: translate(0, 0);
+}
+.reveal.none .slides>section.future {
+	-webkit-transform: translate(0, 0);
+	   -moz-transform: translate(0, 0);
+	    -ms-transform: translate(0, 0);
+	     -o-transform: translate(0, 0);
+	        transform: translate(0, 0);
+}
+
+.reveal.none .slides>section>section.past {
+	-webkit-transform: translate(0, 0);
+	   -moz-transform: translate(0, 0);
+	    -ms-transform: translate(0, 0);
+	     -o-transform: translate(0, 0);
+	        transform: translate(0, 0);
+}
+.reveal.none .slides>section>section.future {
+	-webkit-transform: translate(0, 0);
+	   -moz-transform: translate(0, 0);
+	    -ms-transform: translate(0, 0);
+	     -o-transform: translate(0, 0);
+	        transform: translate(0, 0);
+}
+
+.reveal.none .slides > section, .reveal.none .slides > section > section {
+  -webkit-transform-style: initial;
+   -moz-transform-style: initial;
+    -ms-transform-style: initial;
+        transform-style: initial;
+
+  -webkit-transition: none;
+     -moz-transition: none;
+      -ms-transition: none;
+       -o-transition: none;
+          transition: none;
+}
 
 /*********************************************
  * LINEAR TRANSITION

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@ function linkify( selector ) {
 				history: true,
 				
 				theme: Reveal.getQueryHash().theme || 'default', // available themes are in /css/theme
-				transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/linear(2d)
+				transition: Reveal.getQueryHash().transition || 'default', // default/cube/page/concave/linear(2d)/none
 
 				// Optional libraries used to extend on reveal.js
 				dependencies: [

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -46,7 +46,7 @@ var Reveal = (function(){
 			theme: 'default', 
 
 			// Transition style
-			transition: 'default', // default/cube/page/concave/linear(2d),
+			transition: 'default', // default/cube/page/concave/linear(2d)/none,
 
 			// Script dependencies to load
 			dependencies: []


### PR DESCRIPTION
I didn't see anything built in to reveal to disable animations so I made a new class that overrides all the slide animations and un-animates them
