### PR TITLE
Add proof of concept for CSS fragments

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -1054,3 +1054,37 @@ body {
 }
 
 
+/*********************************************
+ * CSS FRAGMENTS
+ *********************************************/
+
+.reveal .offscreen {
+	position: absolute;
+	left: -10000px;
+}
+
+.animate {
+	-webkit-transition: all 1s ease-in-out;
+	-moz-transition: all 1s ease-in-out;
+	-o-transition: all 1s ease-in-out;
+	transition: all 1s ease-in-out;
+}
+
+.zoom {
+	font-size: 200% !important;
+}
+
+.shrink {
+	font-size: 50% !important;
+}
+
+.red {
+	color: red;
+}
+
+/* Just a marker class for css fragments */
+.css-fragment {
+
+}
+
+

--- a/index.html
+++ b/index.html
@@ -38,6 +38,21 @@
 			<div class="slides">
 
 				<section>
+					<h2>CSS Fragments</h2>
+					<p id="someParagraph" class="animate">
+						You can also make text <span id="makeBigger" class="animate">bigger</span>
+						or <span id="makeSmaller" class="animate">smaller</span>...
+					</p>
+
+					<div class="offscreen fragment css-fragment" data-add-class="zoom" data-target="#makeBigger"></div>
+					<div class="fragment css-fragment" data-add-class="shrink" data-target="#makeSmaller">
+						using <span id="removeRed" class="red animate">CSS fragments</span>.
+					</div>
+
+					<div class="offscreen fragment css-fragment" data-remove-class="red" data-target="#removeRed"></div>
+				</section>
+
+				<section>
 					<h1>Reveal.js</h1>
 					<h3>HTML Presentations Made Easy</h3>
 				</section>
@@ -325,7 +340,7 @@ function linkify( selector ) {
 		</div>
 
 		<script src="lib/js/head.min.js"></script>
-		<script src="js/reveal.min.js"></script>
+		<script src="js/reveal.js"></script>
 
 		<script>
 			

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -934,6 +934,8 @@ var Reveal = (function(){
 			if( verticalFragments.length ) {
 				verticalFragments[0].classList.add( 'visible' );
 
+				handleCSSFragments(verticalFragments[0], true);
+
 				// Notify subscribers of the change
 				dispatchEvent( 'fragmentshown', { fragment: verticalFragments[0] } );
 				return true;
@@ -944,6 +946,8 @@ var Reveal = (function(){
 			var horizontalFragments = document.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR + '.present .fragment:not(.visible)' );
 			if( horizontalFragments.length ) {
 				horizontalFragments[0].classList.add( 'visible' );
+
+				handleCSSFragments(horizontalFragments[0], false);
 
 				// Notify subscribers of the change
 				dispatchEvent( 'fragmentshown', { fragment: horizontalFragments[0] } );
@@ -967,6 +971,8 @@ var Reveal = (function(){
 			if( verticalFragments.length ) {
 				verticalFragments[ verticalFragments.length - 1 ].classList.remove( 'visible' );
 
+				handleCSSFragments(verticalFragments[ verticalFragments.length - 1 ], true);
+
 				// Notify subscribers of the change
 				dispatchEvent( 'fragmenthidden', { fragment: verticalFragments[ verticalFragments.length - 1 ] } );
 				return true;
@@ -978,13 +984,46 @@ var Reveal = (function(){
 			if( horizontalFragments.length ) {
 				horizontalFragments[ horizontalFragments.length - 1 ].classList.remove( 'visible' );
 
+				handleCSSFragments(horizontalFragments[ horizontalFragments.length - 1 ], true);
+
 				// Notify subscribers of the change
 				dispatchEvent( 'fragmenthidden', { fragment: horizontalFragments[ horizontalFragments.length - 1 ] } );
 				return true;
 			}
 		}
-		
+
 		return false;
+	}
+
+	/**
+	 * Handles addition or removal of CSS classes when using CSS fragments.
+	 *
+	 * @param {HTMLElement} The element with the "fragment" class that has been made
+	 * visible and is now checked for CSS fragments.
+	 * @param {boolean} If the CSS fragment operation should be applied in reverse order
+	 * (when the fragment is being removed instead of shown), this flag needs to be set to
+	 * true.
+	 *
+	 * @return {void}
+	 */
+	function handleCSSFragments(element, reverse) {
+		if(!element.classList.contains('css-fragment')) {
+			return;
+		}
+
+		var addClass = element.getAttribute('data-add-class');
+		var removeClass = element.getAttribute('data-remove-class');
+		var target = element.getAttribute('data-target');
+
+		if(reverse) {
+			var temp = addClass;
+			addClass = removeClass;
+			removeClass = temp;
+
+		}
+
+		document.querySelectorAll( target )[0].classList.add( addClass );
+		document.querySelectorAll( target )[0].classList.remove( removeClass );
 	}
 
 	/**


### PR DESCRIPTION
This was suggested by a friend of mine today, and I tried to implement it.
What do you think of it? I'm ready for criticism :smile_cat:

Preview: [On the first slide](http://x3ro.github.com/reveal.js/)
### Commit message

Using CSS fragments, one can add or remove CSS classes using the same
mechanism as when adding step-by-step content. In addition to the
"fragment" class, one needs to add a "css-fragment" class as well as a
"data-target" attribute which specifies the target for the css class
addition or removal.
The latter are specified using "data-add-class" and "data-remove-class".
