### PR TITLE
Fix callback calling when using from a parent directory

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -232,7 +232,7 @@ var Reveal = (function(){
 
 				// Extension may contain callback functions
 				if( typeof s.callback === 'function' ) {
-					head.ready( s.src.match( /([\w\d_\-]*)\.?js|[^\\\/]*$/i )[0], s.callback );
+					head.ready( s.src.match( /([\w\d_\-]*)\.?js$|[^\\\/]*$/i )[0], s.callback );
 				}
 			}
 		}


### PR DESCRIPTION
Authors might want to use a shared reveal.js installation for all their
presentations such as:

```
$ ls -1 -F
20120105-how-to-use-git.html
20121101-wikimedia-scaling.html
reveal.js/
$
```

In this case, the plugin callbacks will not be called at all.

When using head.js, the callback is marked as depending upon the loading
of a Javscript filename. The regex used to find out the filename is applied
to the full path which in the above case would be something like:

```
reveal.js/plugin/highlight/highlight.js
```

The regex will thus give out 'reveal.js' as a file depency instead of
the expected 'highlight.js'

The fix is quiet easy: simply make sure that we are looking for a file
that actually ends with '.js' instead of simply containing '.js' by
adding a $.
