### PR TITLE
Document vertical centering breaking backcompat

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Reveal.initialize({
 });
 ```
 
+Note that the new default vertical centering option will break compatibility with slides that were using transitions with backgrounds (`cube` and `page`). To restore the previous behavior, set `center` to `false`.
+
 ### Dependencies
 
 Reveal.js doesn't _rely_ on any third party scripts to work but a few optional libraries are included by default. These libraries are loaded as dependencies in the order they appear, for example:


### PR DESCRIPTION
Essentially, slides have variable height now. This is not normally visible, but with transitions that have a non-transparent background, like `cube` or `page`, it is:

http://lab.hakim.se/reveal-js/?transition=cube

Before, slides had a fixed height, which means that presentations designed with that assumption in mind will look very different now.

Another aspect that I bumped into is that I used the slide's height to dynamically size images to fill the remainder of the space from the heading to the footer, like this (stripped to the essence):

```
bigImage.style.height = section.offsetHeight - bigImage.offsetTop + 'px';
```

This again wouldn't work by default.
