### PR TITLE
Update grunt-contrib-mincss version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
 		"mustache" : "~0.4.0"
 	},
 	"devDependencies": {
-		"grunt-contrib-mincss": "~0.3.2"
+		"grunt-contrib-mincss": "~0.3.1"
 	}
 }


### PR DESCRIPTION
I tried getting the development environment up the other day, and ran
into issues with the npm install:

```
npm ERR! Error: No compatible version found: grunt-contrib-mincss@'>=0.3.2- <0.4.0-'
npm ERR! Valid install targets:
npm ERR! ["0.1.0","0.2.0","0.3.0","0.3.1"]
npm ERR!     at installTargetsError (/usr/local/lib/node_modules/npm/lib/cache.js:485:10)
npm ERR!     at next_ (/usr/local/lib/node_modules/npm/lib/cache.js:435:17)
npm ERR!     at next (/usr/local/lib/node_modules/npm/lib/cache.js:412:44)
npm ERR!     at /usr/local/lib/node_modules/npm/lib/cache.js:405:5
npm ERR!     at saved (/usr/local/lib/node_modules/npm/lib/utils/npm-registry-client/get.js:151:7)
npm ERR!     at Object.oncomplete (/usr/local/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:230:7)
npm ERR! You may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
npm ERR!
npm ERR! System Darwin 12.2.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Users/technicalpickles/code/vendor/reveal.js
npm ERR! node -v v0.6.15
npm ERR! npm -v 1.1.23
npm ERR! message No compatible version found: grunt-contrib-mincss@'>=0.3.2- <0.4.0-'
npm ERR! message Valid install targets:
npm ERR! message ["0.1.0","0.2.0","0.3.0","0.3.1"]
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/technicalpickles/code/vendor/reveal.js/npm-debug.log
npm not ok
```

According to [the grunt-contrib-mincss npm
page](https://npmjs.org/package/grunt-contrib-mincss), there should be
0.3.2, but for whatever reason I'm not able to install it. I was able to
drop the verison to 0.3.1, and all is well.

**Edit** Sorry for empty body, was trying to submit with `hub`.
