### PR TITLE
Fix bug with switching to 'night' theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
 						<a href="?theme=beige#/themes">Beige</a> -
 						<a href="?theme=simple#/themes">Simple</a> -
 						<a href="?theme=serif#/themes">Serif</a> -
-						<a href="?theme=night#/night">Night</a> -
+						<a href="?theme=night#/themes">Night</a> -
 						<a href="?#/themes">Default</a>
 					</p>
 					<p>


### PR DESCRIPTION
When switching to 'night' theme, the first slide was shown
instead of correctly linking to the Themes slide.
