### PR TITLE
Added phantomjs script for easier printing

### DIFF
--- a/js/print-pdf.js
+++ b/js/print-pdf.js
@@ -1,0 +1,27 @@
+// html2pdf.js
+var page = new WebPage();
+var system = require("system");
+
+page.paperSize = {
+  format: "A4",
+  orientation: "landscape",
+  margin: {
+	left:"0", 
+	right:"0", 
+	top:"0", 
+	bottom:"0"
+  }
+};
+page.zoomFactor = 1.5;
+
+var revealFile = system.args[1] || 'index.html?print-pdf';
+var slideFile = system.args[2] || 'slides.pdf';
+
+if(slideFile.length - 4 != slideFile.lastIndexOf('.pdf')) {
+	slideFile += '.pdf';
+}
+
+page.open(revealFile, function (status) {
+	page.render(slideFile);
+	phantom.exit();
+});


### PR DESCRIPTION
Added `js/print-pdf.js` so you just need to run the following command on the console to have your reveal slides printed to a pdf:
`$ phantomjs js/print-pdf.js [reveal-file.html] [output-file.pdf]`

(requires phantomjs, of course)

// edit:
default filenames are `index.html?print-pdf` for input file and `slides.pdf` for output file
