### PR TITLE
disable remotes plugin on mobile

### DIFF
--- a/plugin/remotes/remotes.js
+++ b/plugin/remotes/remotes.js
@@ -3,17 +3,28 @@
  * of the folks at http://remotes.io
  */
 
-head.ready( 'remotes.ne.min.js', function() {
-	
-	new Remotes("preview")
-		.on("swipe-left", function(e){ Reveal.right(); })
-		.on("swipe-right", function(e){ Reveal.left(); })
-		.on("swipe-up", function(e){ Reveal.down(); })
-		.on("swipe-down", function(e){ Reveal.up(); })
-		.on("tap", function(e){ 
-			Reveal.toggleOverview(); 
-		});
+(function(window){
 
-} );
+    /**
+     * Detects if we are dealing with a touch enabled device (with some false positives)
+     * Borrowed from modernizr: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touch.js   
+     */
+    var hasTouch  = (function(){
+        return ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
+    })();
 
-head.js( 'https://raw.github.com/Remotes/Remotes/master/dist/remotes.ne.min.js' );
+    if(!hasTouch){
+        head.ready( 'remotes.ne.min.js', function() {
+            new Remotes("preview")
+                .on("swipe-left", function(e){ Reveal.right(); })
+                .on("swipe-right", function(e){ Reveal.left(); })
+                .on("swipe-up", function(e){ Reveal.down(); })
+                .on("swipe-down", function(e){ Reveal.up(); })
+                .on("tap", function(e){ 
+                    Reveal.toggleOverview(); 
+                });
+        } );
+
+        head.js('https://raw.github.com/Remotes/Remotes/master/dist/remotes.ne.min.js');
+    }
+})(window);


### PR DESCRIPTION
This commit hides remotes plugin on mobile (assuming it's activated in the first place). 

Here's a [demo](https://dl.dropbox.com/u/9224326/www/revealjs/index.html). The demo will have remotes tab when run on the desktop and none on phones and tablets - saving screen real estate and network bandwidth.   
