### PR TITLE
Small additions around "togglePause()" 

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1612,6 +1612,9 @@ var Reveal = (function(){
 		// Toggles the overview mode on/off
 		toggleOverview: toggleOverview,
 
+		// Toggles the "black screen" mode on/off
+		togglePause: togglePause,
+
 		// Adds or removes all internal event listeners (such as keyboard)
 		addEventListeners: addEventListeners,
 		removeEventListeners: removeEventListeners,


### PR DESCRIPTION
Hello !

These 2 commits add 2 micro features :
- the `togglePause()` method is now "public", in case anyone needs to trigger it from its own JavaScript
- the "191" keyCode triggers this `togglePause()` method : this adds compatibility with the Logitech presenter tools "black screen" button (I only own the [R400](http://www.amazon.com/Logitech-910-001354-Wireless-Presenter-R400/dp/B002GHBUTK/ref=sr_1_1?s=electronics&ie=UTF8&qid=1358525203&sr=1-1&keywords=r400+logitech), but I guess that other Logitech similar tools send the same key code)
