### PR TITLE
Only allow 'unpause' keyboard events while paused

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -563,7 +563,7 @@ var Reveal = (function(){
 					continue;
 				}
 
-				// Vertical stacks are not centered since their section 
+				// Vertical stacks are not centered since their section
 				// children will be
 				if( slide.classList.contains( 'stack' ) ) {
 					slide.style.top = 0;
@@ -594,7 +594,7 @@ var Reveal = (function(){
 	}
 
 	/**
-	 * Retrieves the vertical index which was stored using 
+	 * Retrieves the vertical index which was stored using
 	 * #setPreviousVerticalIndex() or 0 if no previous index
 	 * exists.
 	 *
@@ -1066,7 +1066,7 @@ var Reveal = (function(){
 			var slideAutoSlide = slides[index].getAttribute( 'data-autoslide' );
 			if( slideAutoSlide ) {
 				autoSlide = parseInt( slideAutoSlide, 10 );
-			} 
+			}
 			else {
 				autoSlide = config.autoSlide;
 			}
@@ -1479,6 +1479,11 @@ var Reveal = (function(){
 		if ( hasFocus || event.shiftKey || event.altKey || event.ctrlKey || event.metaKey ) return;
 
 		var triggered = true;
+
+		// while paused only allow "unpausing" keyboard events (b and .)
+		if (isPaused() && [66,190,191].indexOf(event.keyCode) === -1 ) {
+			return false;
+		}
 
 		switch( event.keyCode ) {
 			// p, page up


### PR DESCRIPTION
As a user I expect that when I pause a presentation by pressing either `b` or `.` the presentation should go into a suspended state until I press one of those keys again.

I tested it out in the online version and was able to change slides by pressing the L/R arrow keys while the slide was paused.

This pull request adds that expected behaviour.
