### PR TITLE
notes plugin: open html file with relative path to the notes.js file

### DIFF
--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -5,7 +5,9 @@
 var RevealNotes = (function() {
 
 	function openNotes() {
-		var notesPopup = window.open( 'plugin/notes/notes.html', 'reveal.js - Notes', 'width=1120,height=850' );
+		var jsFileLocation = document.querySelector('script[src*=notes]').src;  // this js file path
+		jsFileLocation = jsFileLocation.replace(/notes\.js(\?.*)?$/, '');   // the js folder path
+		var notesPopup = window.open( jsFileLocation + 'notes.html', 'reveal.js - Notes', 'width=1120,height=850' );
 
 		// Fires when slide is changed
 		Reveal.addEventListener( 'slidechanged', function( event ) {


### PR DESCRIPTION
With this patch when notes.js opens the html page with the speaker notes, it'll find the correct path to it, relative to itself.

The trick is finding the `<script>` tag for `notes.js` and find the correct path from it's src attribute.

This is useful when reveal.js is included from another directory - in my case I have this structure:

```
prez1/
prez2/
reveal.js/ (a git subtree)
```

including it with ../reveal.js/...
