### PR TITLE
check window.ontouchstart != null (required for qtwebkit)

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -439,7 +439,7 @@ var Reveal = (function(){
 		}
 
 		if ( config.controls && dom.controls ) {
-			var actionEvent = 'ontouchstart' in window ? 'touchstart' : 'click';
+			var actionEvent = 'ontouchstart' in window && window.ontouchstart != null ? 'touchstart' : 'click';
 			dom.controlsLeft.forEach( function( el ) { el.removeEventListener( actionEvent, onNavigateLeftClicked, false ); } );
 			dom.controlsRight.forEach( function( el ) { el.removeEventListener( actionEvent, onNavigateRightClicked, false ); } );
 			dom.controlsUp.forEach( function( el ) { el.removeEventListener( actionEvent, onNavigateUpClicked, false ); } );


### PR DESCRIPTION
QtWebKit defines window.ontouchstart but sets it to null. Therefore, in order to correctly detect touch event support in QtWebkit an additional check for window.ontouchstart != null is required.

This webkit bug thread has an extended discussion and the conclusion was that this is not technically a bug in webkit and that javascript libraries (in this case highcharts) should add this check:

https://bugs.webkit.org/show_bug.cgi?id=60879

Here is the highcharts fix:

https://github.com/highslide-software/highcharts.com/issues/1331

Here's a similar issue encountered with fancy box:

http://stackoverflow.com/questions/13347617/fancybox2-determines-qtwebkit-as-touch-device

Note that this pull request does not include a rebuild of reveal.min.js (I don't have the tools to do this setup). Apologize for the incomplete patch, you might prefer a different idiom for doing the check in any case, hopefully this just sheds light on the issue.
