### PR TITLE
Fix for initialization bug when turning off controls and progress in initialization

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -347,8 +347,11 @@ var Reveal = (function(){
 
 		dom.wrapper.classList.add( config.transition );
 
-		dom.controls.style.display = ( config.controls && dom.controls ) ? 'block' : 'none';
-		dom.progress.style.display = ( config.progress && dom.progress ) ? 'block' : 'none';
+		if (dom.controls)
+			dom.controls.style.display = ( config.controls && dom.controls ) ? 'block' : 'none';
+
+		if (dom.progress)
+			dom.progress.style.display = ( config.progress && dom.progress ) ? 'block' : 'none';
 
 		if( config.rtl ) {
 			dom.wrapper.classList.add( 'rtl' );


### PR DESCRIPTION
Couldn't turn off controls and progress during Reveal.initialize()
