### PR TITLE
bugfix - continue autoslide after resume

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -977,9 +977,9 @@ var Reveal = (function(){
 	function resume() {
 
 		var wasPaused = dom.wrapper.classList.contains( 'paused' );
+		dom.wrapper.classList.remove( 'paused' );
 
 		cueAutoSlide();
-		dom.wrapper.classList.remove( 'paused' );
 
 		if( wasPaused ) {
 			dispatchEvent( 'resumed' );


### PR DESCRIPTION
Fixes a bug where pausing then resuming cancels the autoSlide.

How to reproduce:
1. set autoSlide
2. pause
3. resume
4. wait for autoSlide to kick-in
