### PR TITLE
Better error reporting for external Markdown files

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -26,11 +26,11 @@
         return text;
 
     };
-    
+
     var twrap = function(el) {
       return '<script type="text/template">' + el + '</script>';
     };
-    
+
     var slidifyMarkdown = function(markdown, separator, vertical) {
 
         separator = separator || '^\n---\n$';
@@ -105,7 +105,8 @@
                             section.outerHTML = slidifyMarkdown( xhr.responseText, section.getAttribute('data-separator'), section.getAttribute('data-vertical') );
                         } else {
                             section.outerHTML = '<section data-state="alert">ERROR: The attempt to fetch ' + url + ' failed with the HTTP status ' + xhr.status +
-                                '. Check your browser\'s JavaScript console for more details.</section>';
+                                '. Check your browser\'s JavaScript console for more details.' +
+                                '<p>Remember that you need to serve the presentation HTML from a HTTP server and the Markdown file must be there too.</p></section>';
                         }
                     }
                 };


### PR DESCRIPTION
1. Show an alert when loading the file throws an exception
2. Whenever the status isn't success (2xx) - upon exception or e.g.
   "file not found" - replace the section's content with information
   about the failure (instead of being silent about it and showing
   a blank slide).

We need to inform the user something went wrong, not just be silent
about it. An experienced developer, upon seing a blank slide, will
likely check the javascript console - but the rest will profit from
being told about the problem (and solution) explicitely.
