### PR TITLE
Add Reveal.js license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-sass": "~0.2.2",
     "grunt": "~0.4.0"
-  }
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/hakimel/reveal.js/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
NPM spec allows for the Reveal.js license in the package.json, so for completeness, I added it in :)

https://npmjs.org/doc/json.html
