### PR TITLE
problem using notes and remote plugin together

### DIFF
--- a/plugin/remotes/remotes.js
+++ b/plugin/remotes/remotes.js
@@ -13,7 +13,15 @@
         return ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
     })();
 
-    if(!hasTouch){
+    /**
+     * Detects if notes are enable and the current page is opened inside an /iframe
+     * this prevents loading Remotes.io several times
+     */
+    var remotesAndIsNotes = (function(){
+      return !(window.RevealNotes && self == top);
+    })();
+
+    if(!hasTouch && !remotesAndIsNotes){
         head.ready( 'remotes.ne.min.js', function() {
             new Remotes("preview")
                 .on("swipe-left", function(e){ Reveal.right(); })


### PR DESCRIPTION
if using notes and remote plugin together the remote plugin is being loaded in the notes windows several times generating some errors when controlling the main slideshow, for example you can miss some slides.

In this _pull request_ I just check if the notes are enabled and if the slideshow is being loaded in an /iframe element(the notes window).
