### PR TITLE
Add support for setting the start of a vertical stack.

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,10 +60,18 @@
 				<!-- Example of nested vertical slides -->
 				<section>
 					<section>
+						<h2>First Floor</h2>
+						<p>
+							You can set any slide to be the start of a vertical stack,
+							just add the class .stack-start
+						</p>
+					</section>
+					<section class="stack-start">
 						<h2>Vertical Slides</h2>
 						<p>
 							Slides can be nested inside of other slides,
-							try pressing <a href="#" class="navigate-down">down</a>.
+							try pressing <a href="#" class="navigate-up">up</a>
+							or <a href="#" class="navigate-down">down</a>.
 						</p>
 						<a href="#" class="image navigate-down">
 							<img width="178" height="238" src="https://s3.amazonaws.com/hakim-static/reveal-js/arrow.png" alt="Down arrow">

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -748,11 +748,26 @@ var Reveal = (function(){
 	function getPreviousVerticalIndex( stack ) {
 
 		if( typeof stack === 'object' && typeof stack.setAttribute === 'function' && stack.classList.contains( 'stack' ) ) {
-			return parseInt( stack.getAttribute( 'data-previous-indexv' ) || 0, 10 );
+			if ( stack.hasAttribute( 'data-previous-indexv' ) ) {
+				return parseInt( stack.getAttribute( 'data-previous-indexv' ), 10 );
+			}
+			return getStackStart( stack );
 		}
 
 		return 0;
 
+	}
+
+	/**
+	 * Calculates the starting slide of a stack, based on which one
+	 * has the class '.stack-start' or 0 if no start has been designated.
+	 *
+	 * @param {HTMLElement} stack The vertical stack element
+	 */
+	function getStackStart( stack )  {
+		var stackSections = Array.prototype.slice.call( stack.querySelectorAll('section') );
+		var stackCenter = stackSections.indexOf( stack.querySelector('section.stack-start') );
+		return stackCenter === -1 ? 0 : stackCenter;
 	}
 
 	/**
@@ -1157,7 +1172,7 @@ var Reveal = (function(){
 					for( i in slides ) {
 						if( slides[i] ) {
 							// Reset stack
-							setPreviousVerticalIndex( slides[i], 0 );
+							setPreviousVerticalIndex( slides[i], getStackStart ( slides[i] ) );
 						}
 					}
 				}, 0 );


### PR DESCRIPTION
This addresses issue #427. 

This allows you to specify the slide in a vertical stack to start at, instead of always starting at the top of the stack, you can now start at any slide by adding the class "stack-start".

Updated index.html to add an example of it in action.

// Probably did this pull request wrong, so please let me know if you need anything changing. 
