### PR TITLE
Allow override of HTML escaping in code blocks

### DIFF
--- a/plugin/highlight/highlight.js
+++ b/plugin/highlight/highlight.js
@@ -11,8 +11,10 @@
 				element.innerHTML = element.innerHTML.trim();
 			}
 
-			// Now escape html
-			element.innerHTML = element.innerHTML.replace(/</g,"&lt;").replace(/>/g,"&gt;");
+			// Now escape html unless prevented by author
+			if( ! element.hasAttribute( 'data-noescape' )) {
+				element.innerHTML = element.innerHTML.replace(/</g,"&lt;").replace(/>/g,"&gt;");
+			}
 
 			// re-highlight when focus is lost (for edited code)
 			element.addEventListener( 'focusout', function( event ) {


### PR DESCRIPTION
Hi Hakim & al,

first off: thanks for your hard work on reveal.js, it has become my main presentation tool.

I noticed PR #432 now escapes all HTML in code blocks. This is unfortunate for me, since I often use HTML and fragments to highlight portions of code I'm talking about. (I even wrote a small plugin for this - you can see it in action [here](http://ericweikl.github.io/revealjs-charred/#/2).) With the current version, this doesn't work anymore and prints the escaped HTML instead.

The attached PR allows you to prevent HTML escaping by supplying an attribute `data-noescape`, similar to the `data-trim` attribute. By default, HTML will remain escaped, which makes sense IMO.
