### PR TITLE
Fix Touch events don't work on IE10

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@ function linkify( selector ) {
 		</div>
 
 		<script src="lib/js/head.min.js"></script>
-		<script src="js/reveal.min.js"></script>
+		<script src="js/reveal.js"></script>
 
 		<script>
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -184,6 +184,11 @@ var Reveal = (function(){
 		// Cache references to key DOM elements
 		dom.theme = document.querySelector( '#theme' );
 		dom.wrapper = document.querySelector( '.reveal' );
+
+        if( window.navigator.msPointerEnabled ) {
+            //if msPointers is present, we need stablis msTouchAction style to none.
+            dom.wrapper.style.msTouchAction = "none";
+        }
 		dom.slides = document.querySelector( '.reveal .slides' );
 
 		// Progress bar


### PR DESCRIPTION
Hello,

I add the necessary script to add the set msTouchAction style to "none" for work on IE10 touch.

Note: only reveal.js was modified, you need to create minified version.
