### PR TITLE
Updated console instructions for launching notes

### DIFF
--- a/plugin/notes-server/index.js
+++ b/plugin/notes-server/index.js
@@ -54,5 +54,5 @@ var slidesLocation = "http://localhost" + ( opts.port ? ( ':' + opts.port ) : ''
 
 console.log( brown + "reveal.js - Speaker Notes" + reset );
 console.log( "1. Open the slides at " + green + slidesLocation + reset );
-console.log( "2. Click on the link your JS console to go to the notes page" );
+console.log( "2. Press the 's' key on your keyboard to open the notes window" );
 console.log( "3. Advance through your slides and your notes will advance automatically" );


### PR DESCRIPTION
When running the notes-server plugin, the node console had a message
that said to look in the JS console for a link to the notes page.  The
JS console log message no longer appears, so I have updated the node
console message to reflect how the notes page should be opened (pressing
the 's' key) as described in the documentation.

From the documentation and from https://github.com/hakimel/reveal.js/issues/381, it appears that pressing 's' is the proper way to launch notes now.
