### PR TITLE
Use Math.floor instead of parseInt

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -212,9 +212,9 @@
 							now = new Date();
 
 						diff = now.getTime() - start.getTime();
-						hours = parseInt( diff / ( 1000 * 60 * 60 ) );
-						minutes = parseInt( ( diff / ( 1000 * 60 ) ) % 60 );
-						seconds = parseInt( ( diff / 1000 ) % 60 );
+						hours = Math.floor( diff / ( 1000 * 60 * 60 ) );
+						minutes = Math.floor( ( diff / ( 1000 * 60 ) ) % 60 );
+						seconds = Math.floor( ( diff / 1000 ) % 60 );
 
 						clockEl.innerHTML = now.toLocaleTimeString();
 						hoursEl.innerHTML = zeroPadInteger( hours );


### PR DESCRIPTION
I had the timer randomly flashing up 2 hours when opening the presenter view. This should fix it.
