### PR TITLE
Only start/stop embedded content if slide has actually changed

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1128,7 +1128,8 @@ var Reveal = (function(){
 		}
 
 		// Dispatch an event if the slide changed
-		if( indexh !== indexhBefore || indexv !== indexvBefore ) {
+		var slideChanged = (indexh !== indexhBefore || indexv !== indexvBefore);
+		if( slideChanged ) {
 			dispatchEvent( 'slidechanged', {
 				'indexh': indexh,
 				'indexv': indexv,
@@ -1165,8 +1166,10 @@ var Reveal = (function(){
 		}
 
 		// Handle embedded content
-		stopEmbeddedContent( previousSlide );
-		startEmbeddedContent( currentSlide );
+		if (slideChanged) {
+			stopEmbeddedContent( previousSlide );
+			startEmbeddedContent( currentSlide );
+		}
 
 		updateControls();
 		updateProgress();


### PR DESCRIPTION
This patch should fix [issue #478](https://github.com/hakimel/reveal.js/issues/478) by only calling stopEmbeddedContent and startEmbeddedContent if the slide has actually changed.
