### PR TITLE
Notes view glitches when using multiple elements with same data-fragment-index

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1916,10 +1916,10 @@ var Reveal = (function(){
 
 				toArray( fragments ).forEach( function( element ) {
 					element.classList.add( 'visible' );
-
-					// Notify subscribers of the change
-					dispatchEvent( 'fragmentshown', { fragment: element } );
 				} );
+
+				// Notify subscribers of the change
+				dispatchEvent( 'fragmentshown', { fragment: fragments[0], fragments: fragments } );
 
 				updateControls();
 				return true;
@@ -1950,10 +1950,10 @@ var Reveal = (function(){
 
 				toArray( fragments ).forEach( function( f ) {
 					f.classList.remove( 'visible' );
-
-					// Notify subscribers of the change
-					dispatchEvent( 'fragmenthidden', { fragment: f } );
 				} );
+
+				// Notify subscribers of the change
+				dispatchEvent( 'fragmenthidden', { fragment: fragments[0], fragments: fragments } );
 
 				updateControls();
 				return true;


### PR DESCRIPTION
PR #435 added the very useful possibility to assign the same data-fragment-index to multiple fragments and show/hide them at once.

This breaks the notes view, however, since each fragment triggers a fragmenshown / fragmenthidden event. The notes plugin calls Reveal.nextFragment() / Reveal.prevFragment() on each received event, so the notes view progresses too fast. I assume this also affects the notes-server plugin, but I didn't check.

The notes plugin could be changed to filter out additional events. Another is to create a single event for all displayed fragments with the same index. This pull request does just that.

For backwards-compatibility, the fragment property of the event still returns a single fragment. A new property (fragments) contains all fragments that were displayed.

What do you think?
