### PR TITLE
Make header margin an overridable setting

### DIFF
--- a/css/theme/template/settings.scss
+++ b/css/theme/template/settings.scss
@@ -10,6 +10,7 @@ $mainFontSize: 36px;
 $mainColor: #eee;
 
 // Headings
+$headingMargin: 0 0 20px 0;
 $headingFont: 'League Gothic', Impact, sans-serif;
 $headingColor: #eee;
 $headingLineHeight: 0.9em;

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -33,7 +33,7 @@ body {
 .reveal h4,
 .reveal h5,
 .reveal h6 {
-	margin: 0 0 20px 0;
+	margin: $headingMargin;
 	color: $headingColor;
 
 	font-family: $headingFont;


### PR DESCRIPTION
This provides more flexibility for writing themes.

Specific changes:
1. `css/theme/template/settings.scss` adds the `$headingMargin` variable, set to `0 0 20px 0`, which is the hardcoded default before this pull request.
2. `css/theme/template/theme.scss` uses `$headingMargin` to set margin on headers.
