### PR TITLE
Add option to Gruntfile.js to specify server port

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 /* global module:false */
 module.exports = function(grunt) {
-
+	var port = grunt.option('port') || 8000;
 	// Project configuration
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
 		connect: {
 			server: {
 				options: {
-					port: 8000,
+					port: port,
 					base: '.'
 				}
 			}


### PR DESCRIPTION
I found this to be quite a nice feature as I was already running other things at port 8000.

I'm not sure though if this is the right way to do it with grunt.
