### PR TITLE
prevent unintended slide change event

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -139,11 +139,11 @@
 	<body>
 
 		<div id="wrap-current-slide" class="slides">
-			<script>document.write( '<iframe width="1280" height="1024" id="current-slide" src="'+ window.opener.location.href +'"></iframe>' );</script>
+			<script>document.write( '<iframe width="1280" height="1024" id="current-slide" src="'+ window.opener.location.href +'?receiver"></iframe>' );</script>
 		</div>
 
 		<div id="wrap-next-slide" class="slides">
-			<script>document.write( '<iframe width="640" height="512" id="next-slide" src="'+ window.opener.location.href +'"></iframe>' );</script>
+			<script>document.write( '<iframe width="640" height="512" id="next-slide" src="'+ window.opener.location.href +'?receiver"></iframe>' );</script>
 			<span>UPCOMING:</span>
 		</div>
 


### PR DESCRIPTION
This prevents the upcoming slide on the notes page from triggering
slidechanged events.  I believe this fixes issue 578, as well.
