### PR TITLE
Add editorconfig.org configuration file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
To simplify the process of contributing, I've added a .editorconfig file to the root of the project. This ensures that compatible editors will use tabs for indentation, strip trailing whitespace, use utf-8 as charset etc.

Take a look at http://editorconfig.org/ for more details on the format and supported editors. Of course, feel free to edit if I've defined some incorrect settings here.
