### PR TITLE
Added support for postMessage's into any iframes for content that needs ...

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2017,6 +2017,11 @@ var Reveal = (function(){
 				}
 			} );
 
+			// iframe embeds
+			toArray( slide.querySelectorAll( 'iframe' ) ).forEach( function( el ) {
+				el.contentWindow.postMessage('slide:start', '*');
+			});
+
 			// YouTube embeds
 			toArray( slide.querySelectorAll( 'iframe[src*="youtube.com/embed/"]' ) ).forEach( function( el ) {
 				if( el.hasAttribute( 'data-autoplay' ) ) {
@@ -2040,6 +2045,11 @@ var Reveal = (function(){
 					el.pause();
 				}
 			} );
+
+			// iframe embeds
+			toArray( slide.querySelectorAll( 'iframe' ) ).forEach( function( el ) {
+				el.contentWindow.postMessage('slide:stop', '*');
+			});
 
 			// YouTube embeds
 			toArray( slide.querySelectorAll( 'iframe[src*="youtube.com/embed/"]' ) ).forEach( function( el ) {


### PR DESCRIPTION
...to do something when a slide is displayed and hidden.

Second pull request attempt for issue https://github.com/hakimel/reveal.js/issues/661 (addresses rejection issues for pull request https://github.com/hakimel/reveal.js/pull/675)

This patch ignores the `data-ignore` attr for the stop event and targets the dev branch.

Assuming this gets merged, how do I know when this puppy gets deployed into production in slid.es? When it hits master?

Thanks Hakim and cheers!
