### PR TITLE
CSS: Don't override font-weight for section

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -530,7 +530,7 @@ body {
 
 	z-index: 10;
 	line-height: 1.2em;
-	font-weight: normal;
+	font-weight: inherit;
 
 	-webkit-transform-style: preserve-3d;
 	   -moz-transform-style: preserve-3d;


### PR DESCRIPTION
.slides>section and .slides>section>section set the font-weight to
"normal". This overrides any font-weight setting a theme may set at
the body or .reveal level, and requires a theme author to also
specifically set the font-weight for .slides>section and
.slides>section>section. That's tedious and also counterintuitive.

Adopt a saner default by setting the font-weight to inherit.
