### PR TITLE
Indentation issue when using code in a markdown slide

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -49,7 +49,7 @@
 			text = text.replace( new RegExp('\\n?\\t{' + leadingTabs + '}','g'), '\n' );
 		}
 		else if( leadingWs > 1 ) {
-			text = text.replace( new RegExp('\\n? {' + leadingWs + '}','g'), '\n' );
+			text = text.replace( new RegExp('\\n? {' + leadingWs + '}'), '\n' );
 		}
 
 		return text;


### PR DESCRIPTION
For example this markdown slide :

``````
```php
public function foo()
{
    $foo = array(
        'bar' => 'bar'
    )
}
```
``````

Would input

``` php
public function foo()
{
    $foo = array(
'bar' => 'bar'
    )
}
```

Removing global flag in regexp solves this issue, and still remove the first white space, please double check if there is no other regressions.
