### PR TITLE
troublefree livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,9 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
-					base: '.'
+					base: '.',
+                    livereload: true,
+                    open: true
 				}
 			}
 		},
@@ -97,6 +99,9 @@ module.exports = function(grunt) {
 		},
 
 		watch: {
+            options: {
+                livereload: true
+            },
 			main: {
 				files: [ 'Gruntfile.js', 'js/reveal.js', 'css/reveal.css' ],
 				tasks: 'default'
@@ -104,7 +109,10 @@ module.exports = function(grunt) {
 			theme: {
 				files: [ 'css/theme/source/*.scss', 'css/theme/template/*.scss' ],
 				tasks: 'themes'
-			}
+			},
+            html: {
+                files: [ 'index.html']
+            }
 		}
 
 	});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-sass": "~0.5.0",
-    "grunt-contrib-connect": "~0.4.1",
+    "grunt-contrib-connect": "~0.5.0",
     "grunt-zip": "~0.7.0",
     "grunt": "~0.4.0"
   },


### PR DESCRIPTION
let 'grunt serve' start the browser and livereload changes in the presentation
- upgrade grunt-contrib-connect to ~0.5.0
- configure connect and watch plugin
