### PR TITLE
Automatically increase autoSlide timer if media file is played with longer duration 

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1916,6 +1916,10 @@ var Reveal = (function(){
 			// HTML5 media elements
 			toArray( slide.querySelectorAll( 'video, audio' ) ).forEach( function( el ) {
 				if( el.hasAttribute( 'data-autoplay' ) ) {
+					if (autoSlide && el.duration*1000 > autoSlide) {
+						autoSlide = el.duration*1000;
+						cueAutoSlide();
+					}
 					el.play();
 				}
 			} );


### PR DESCRIPTION
Hello Hakim,

this is a change to fix Issue #701. If auto sliding is enabled and if a slide has an HTML5 media element which is played automatically, the auto slide value caused to switch to the next slide before the media files is played completely. With this change the timer is now increased if the duration of the media file is larger than the autoSlide value. With this change one can include audio files for each slide to obtain a slide show in which the next slide is automatically shown after the media file is played.

I hope you consider including this small change. 

(Please, note that this is my first fork and pull request using Github. I hope my usage of this is appropriate. Excuse me if not).

Cheers
