### PR TITLE
Fixes bad NaN applied to style on updateParallax.

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2032,7 +2032,7 @@ var Reveal = (function(){
 
 			var slideHeight = dom.background.offsetHeight;
 			var verticalSlideCount = verticalSlides.length;
-			var verticalOffset = verticalSlideCount > 0 ? -( backgroundHeight - slideHeight ) / ( verticalSlideCount-1 ) * indexv : 0;
+			var verticalOffset = verticalSlideCount > 1 ? -( backgroundHeight - slideHeight ) / ( verticalSlideCount-1 ) * indexv : 0;
 
 			dom.background.style.backgroundPosition = horizontalOffset + 'px ' + verticalOffset + 'px';
 


### PR DESCRIPTION
The previous criteria "verticalSlideCount > 0" would result
in verticalOffset being NaN when verticalSlideCount == 1.

This would cause dom.background.style.backgroundPosition to
be set to something like "123px NaNpx", ultimately preventing
the parallax effect to play (silently failing so far).
