### PR TITLE
Add generated css and js to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ log/*.log
 tmp/**
 node_modules/
 .sass-cache
+css/reveal.min.css
+css/themes/*.css
+js/reveal.min.js


### PR DESCRIPTION
I found it nice to ignore these files, they are automatically generated anyway (i.e. reveal.min.js always has the date of minify-ing, which I don't want to commit all the time). Should just track the source unless there is a good reason to hand-curate these versions.
