### PR TITLE
Add instructions for opening notes window to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ Sometimes it's desirable to have an element, like an image or video, stretch to 
 </section>
 ```
 
-Limitations:no
+Limitations:
 - Only direct descendants of a slide section can be stretched
 - Only one descendant per slide section can be stretched
 


### PR DESCRIPTION
You've written your presentation (so no default markup anymore) and checking out the project README doesn't tell you how to open the window. The instructions are in the markup of the example presentation, but it's probably worth surfacing them here too, so they can be found more easily.
