### PR TITLE
Adds support for deploy a reveal.js app to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node web.js

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   },
   "dependencies": {
     "underscore": "~1.5.1",
-    "express": "~2.5.9",
+    "express": "~3.4.6",
     "mustache": "~0.7.2",
-    "socket.io": "~0.9.13"
+    "socket.io": "~0.9.13",
+    "logfmt": "~0.20.0"
   },
   "devDependencies": {
     "grunt-contrib-qunit": "~0.2.2",

--- a/web.js
+++ b/web.js
@@ -1,0 +1,12 @@
+var express = require("express");
+var logfmt = require("logfmt");
+var app = express();
+
+app.use(logfmt.requestLogger());
+
+app.use("/", express.static(__dirname));
+
+var port = Number(process.env.PORT || 5000);
+app.listen(port, function() {
+  console.log("Listening on " + port);
+});


### PR DESCRIPTION
I have used the official Heroku [docs](https://devcenter.heroku.com/articles/getting-started-with-nodejs) for node.js and the general idea from [Michael Bitard](https://github.com/MichaelBitard/revealjs_heroku). The patch adds the files needed for immediate deploy on Heroku Cedar.
