### PR TITLE
Centered Tables + Fontawesome support

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -18,7 +18,7 @@ html, body, .reveal div, .reveal span, .reveal applet, .reveal object, .reveal i
 .reveal a, .reveal abbr, .reveal acronym, .reveal address, .reveal big, .reveal cite, .reveal code,
 .reveal del, .reveal dfn, .reveal em, .reveal img, .reveal ins, .reveal kbd, .reveal q, .reveal s, .reveal samp,
 .reveal small, .reveal strike, .reveal strong, .reveal sub, .reveal sup, .reveal tt, .reveal var,
-.reveal b, .reveal u, .reveal i, .reveal center,
+.reveal b, .reveal u, .reveal center,
 .reveal dl, .reveal dt, .reveal dd, .reveal ol, .reveal ul, .reveal li,
 .reveal fieldset, .reveal form, .reveal label, .reveal legend,
 .reveal table, .reveal caption, .reveal tbody, .reveal tfoot, .reveal thead, .reveal tr, .reveal th, .reveal td,
@@ -248,8 +248,7 @@ body {
 	font-weight: bold;
 }
 
-.reveal em,
-.reveal i {
+.reveal em {
 	font-style: italic;
 }
 


### PR DESCRIPTION
#### Centered Tables

As the main content of all slides is centered, I wanted to have also tables centered. Additionally, I was not that happy with the paddings inside the table. So this would do the trick ;-)
#### Fontawesome-Fixes

As Fontawesome uses the "i"-Tag, I had to remove reset of "i" (line 21 - this was because of fontawesome font sizes) as well as remove the tag for the italic definition (line 252). Now you can easily add Fontawesome to your slides by putting <link rel="stylesheet" href="css/font-awesome.css"> into the head of the html-file.
