### PR TITLE
Tweak layout in README.md installation markup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,28 +878,28 @@ Some reveal.js features, like external markdown and speaker notes, require that 
 2. Install [Grunt](http://gruntjs.com/getting-started#installing-the-cli)
 
 4. Clone the reveal.js repository
-```sh
-$ git clone https://github.com/hakimel/reveal.js.git
-```
+   ```sh
+   $ git clone https://github.com/hakimel/reveal.js.git
+   ```
 
 5. Navigate to the reveal.js folder
-```sh
-$ cd reveal.js
-```
+   ```sh
+   $ cd reveal.js
+   ```
 
 6. Install dependencies
-```sh
-$ npm install
-```
+   ```sh
+   $ npm install
+   ```
 
 7. Serve the presentation and monitor source files for changes
-```sh
-$ grunt serve
-```
+   ```sh
+   $ grunt serve
+   ```
 
 8. Open <http://localhost:8000> to view your presentation
 
-You can change the port by using `grunt serve --port 8001`.
+   You can change the port by using `grunt serve --port 8001`.
 
 
 ### Folder Structure


### PR DESCRIPTION
Some code blocks weren't indented, so they ended up messing up the numbering. Indenting them fixed it.
