### PR TITLE
Add support for Live Reload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,6 +97,9 @@ module.exports = function(grunt) {
 		},
 
 		watch: {
+			options: {
+				livereload: true,
+			},
 			main: {
 				files: [ 'Gruntfile.js', 'js/reveal.js', 'css/reveal.css' ],
 				tasks: 'default'
@@ -104,6 +107,10 @@ module.exports = function(grunt) {
 			theme: {
 				files: [ 'css/theme/source/*.scss', 'css/theme/template/*.scss' ],
 				tasks: 'themes'
+			},
+			content: {
+				files: [ 'index.html' ],
+				tasks: []
 			}
 		}
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
 			}
 		</script>
 
+		<!-- Live reload -->
+		<script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
+
 		<!--[if lt IE 9]>
 		<script src="lib/js/html5shiv.js"></script>
 		<![endif]-->

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-cssmin": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.4",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-watch": "~0.6.0",
     "grunt-contrib-sass": "~0.5.0",
     "grunt-contrib-connect": "~0.4.1",
     "grunt-zip": "~0.7.0",


### PR DESCRIPTION
When preparing a presentation, it's quite handy to automatically reload the view in the browser when the content changes. I've enabled that with the Live Reload capability of the grunt-watch plugin (don't forget to run 'npm install' again).