### PR TITLE
Mark xhr.status=0 as successful

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -220,9 +220,9 @@
 				xhr.onreadystatechange = function() {
 					if( xhr.readyState === 4 ) {
 						if (
-                            (xhr.status >= 200 && xhr.status < 300) ||
-                            xhr.status === 0 // file protocol yields status code 0 (useful for local debug, mobile applications etc.)
-                            ) {
+							(xhr.status >= 200 && xhr.status < 300) ||
+							xhr.status === 0 // file protocol yields status code 0 (useful for local debug, mobile applications etc.)
+							) {
 
 							section.outerHTML = slidify( xhr.responseText, {
 								separator: section.getAttribute( 'data-separator' ),


### PR DESCRIPTION
File protocol yields status code 0.
To support reveal on mobile application created using Phonegap/Cordova and for local debugging- xhr.status=0 should be marked as successful.

jQuery uses the same concept:
http://code.jquery.com/jquery-2.0.1.js

``` javascript
xhrSuccessStatus = {
        // file protocol always yields status code 0, assume 200
        0: 200,
```
