### PR TITLE
Show fragments in "notes" window

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,12 @@
 				link.href = 'css/print/pdf.css';
 				document.getElementsByTagName( 'head' )[0].appendChild( link );
 			}
+			if( window.location.search.match( /receiver/gi ) ) {
+				var s = document.createElement( 'style' );
+				s.type = 'text/css';
+				s.innerHTML = ".reveal .slides section .fragment { opacity: .5; }";
+				document.getElementsByTagName( 'head' )[0].appendChild( s );
+			}
 		</script>
 
 		<!--[if lt IE 9]>


### PR DESCRIPTION
Just a quality-of-life improvement, allows the presenter to see otherwise hidden fragments through the "notes" plugin.
