### PR TITLE
!important the .slides width and height in the PDF stylesheet

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -94,8 +94,8 @@ ul, ol, div, p {
 }
 .reveal .slides {
 	position: static;
-	width: 100%;
-	height: auto;
+	width: 100% !important;
+	height: auto !important;
 
 	left: auto;
 	top: auto;


### PR DESCRIPTION
The PDF stylesheet doesn't operate correctly when a width and height have been set in the reveal.js options, as width and height rules are added to the element's style attribute, overriding the rules in the PDF stylesheet. This adds !important flags to the PDF rules to ensure they win.
