### PR TITLE
remove height if we have a page-break.

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -124,8 +124,6 @@ ul, ol, div, p {
 	visibility: visible !important;
 	position: relative !important;
 	width: 100% !important;
-	height: 229mm !important;
-	min-height: 229mm !important;
 	display: block !important;
 	overflow: hidden !important;
 


### PR DESCRIPTION
In print we should not dictate content heights because the page-break should take care of it.
If we do it this way we can print the slides in landscape without having double pages.
