### PR TITLE
notes: reset timer on 'r' key press.

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -180,8 +180,20 @@
 						nextSlide = document.getElementById( 'next-slide' ),
 						silenced = false;
 
+					var start = new Date(),
+						timeEl = document.querySelector( '.time' ),
+						clockEl = document.getElementById( 'clock' ),
+						hoursEl = document.getElementById( 'hours' ),
+						minutesEl = document.getElementById( 'minutes' ),
+						secondsEl = document.getElementById( 'seconds' );
+
 					window.addEventListener( 'message', function( event ) {
 						var data = JSON.parse( event.data );
+
+						// Reset the time counter if asked to.
+						if ( data.reset ) {
+							start = new Date();
+						}
 
 						// No need for updating the notes in case of fragment changes
 						if ( data.notes !== undefined) {
@@ -193,22 +205,16 @@
 							}
 						}
 
-						silenced = true;
-
 						// Update the note slides
-						currentSlide.contentWindow.Reveal.slide( data.indexh, data.indexv, data.indexf );
-						nextSlide.contentWindow.Reveal.slide( data.nextindexh, data.nextindexv );
+						if ( data.update ) {
+							silenced = true;
+							currentSlide.contentWindow.Reveal.slide( data.indexh, data.indexv, data.indexf );
+							nextSlide.contentWindow.Reveal.slide( data.nextindexh, data.nextindexv );
+							silenced = false;
+						}
 
-						silenced = false;
 
 					}, false );
-
-					var start = new Date(),
-						timeEl = document.querySelector( '.time' ),
-						clockEl = document.getElementById( 'clock' ),
-						hoursEl = document.getElementById( 'hours' ),
-						minutesEl = document.getElementById( 'minutes' ),
-						secondsEl = document.getElementById( 'seconds' );
 
 					setInterval( function() {
 

--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -4,6 +4,19 @@
  */
 var RevealNotes = (function() {
 
+	function bindKey(keyCode, callback) {
+		// Disregard the event if the target is editable or a
+		// modifier is present
+		document.addEventListener( 'keydown', function( event ) {
+			if ( document.querySelector( ':focus' ) !== null || event.shiftKey || event.altKey || event.ctrlKey || event.metaKey ) return;
+			if ( event.keyCode === keyCode ) { // reset timer on 'r'
+				event.preventDefault();
+				callback();
+			}
+		});
+	}
+
+
 	function openNotes() {
 		var jsFileLocation = document.querySelector('script[src$="notes.js"]').src;  // this js file path
 		jsFileLocation = jsFileLocation.replace(/notes\.js(\?.*)?$/, '');   // the js folder path
@@ -39,6 +52,8 @@ var RevealNotes = (function() {
 			}
 
 			messageData = {
+				update : true,
+				reset : false,
 				notes : notes ? notes.innerHTML : '',
 				indexh : slideIndices.h,
 				indexv : slideIndices.v,
@@ -50,6 +65,12 @@ var RevealNotes = (function() {
 
 			notesPopup.postMessage( JSON.stringify( messageData ), '*' );
 		}
+
+		// Reset timer on 'r'
+		bindKey(82, function() {
+			var messageData = { update : false, reset : true };
+			notesPopup.postMessage( JSON.stringify( messageData ), '*' );
+		});
 
 		// Navigate to the current slide when the notes are loaded
 		notesPopup.addEventListener( 'load', function( event ) {
@@ -63,16 +84,7 @@ var RevealNotes = (function() {
 	}
 
 	// Open the notes when the 's' key is hit
-	document.addEventListener( 'keydown', function( event ) {
-		// Disregard the event if the target is editable or a
-		// modifier is present
-		if ( document.querySelector( ':focus' ) !== null || event.shiftKey || event.altKey || event.ctrlKey || event.metaKey ) return;
-
-		if( event.keyCode === 83 ) {
-			event.preventDefault();
-			openNotes();
-		}
-	}, false );
+	bindKey(83, openNotes);
 
 	return { open: openNotes };
 })();


### PR DESCRIPTION
I used reveal.js together with notes plugin and was annoyed that timer started on opening notes.
Usually you first prepare presentation, together with notes window, and spend a moment before starting it.
So I think it's desirable to have a functionality to reset timer.
Another use case is when a few people speak one by one, with common shared slides, and would like to measure time separately.

Please review the change, I may improve it if needed!