### PR TITLE
Feature prevent swipe

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3482,6 +3482,8 @@
 	 */
 	function onTouchStart( event ) {
 
+		if(preventSwipe(event.target)) return true;
+
 		touch.startX = event.touches[0].clientX;
 		touch.startY = event.touches[0].clientY;
 		touch.startCount = event.touches.length;
@@ -3504,6 +3506,8 @@
 	 * Handler for the 'touchmove' event.
 	 */
 	function onTouchMove( event ) {
+
+		if(preventSwipe(event.target)) return true;
 
 		// Each touch should only trigger one action
 		if( !touch.captured ) {
@@ -3784,6 +3788,15 @@
 			pauseAutoSlide();
 		}
 
+	}
+
+	function preventSwipe(target) {
+		while( target && typeof target.hasAttribute == 'function' ) {
+			if(target.hasAttribute('prevent-swipe')) return true;
+			target = target.parentNode;
+		}
+
+		return false;
 	}
 
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3791,7 +3791,7 @@
 	}
 
 	function preventSwipe(target) {
-		while( target && typeof target.hasAttribute == 'function' ) {
+		while( target && typeof target.hasAttribute === 'function' ) {
 			if(target.hasAttribute('prevent-swipe')) return true;
 			target = target.parentNode;
 		}


### PR DESCRIPTION
Add ability to prevent swipe for child elements with the `prevent-swipe` attribute.

Basically, it allow users to add scroll/swipe interaction on elements, without swiping to another slide.