### PR TITLE
Title-Footer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,6 +854,31 @@ Reveal.initialize({
 Read MathJax's documentation if you need [HTTPS delivery](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn) or serving of [specific versions](http://docs.mathjax.org/en/latest/configuration.html#loading-mathjax-from-the-cdn) for stability.
 
 
+## Title-Footer
+
+This plugin includes a footer in all the slides (with optional exclusion of some slides) showing the title of the presentation. It takes the first ```h1```, ```h2``` and ```h3``` tags from the first slide as the title, if another title is not explicitly passed as parameter in the initialization. The title footer will not be shown in a slide if the corresponding section has a ```data-state``` attribute with a value of ```no-title-footer```. You can find an example of it working at [http://e-gor.github.io/Reveal.js-Title-Footer/demo](http://e-gor.github.io/Reveal.js-Title-Footer/demo) and instructions of use at [https://github.com/e-gor/Reveal.js-Title-Footer](https://github.com/e-gor/Reveal.js-Title-Footer).
+
+Example configuration:
+
+```javascript
+Reveal.initialize
+(
+	{
+		...
+		dependencies:
+		[
+			...
+			{ src: 'plugin/title-footer/title-footer.js', async: true, callback: function() { title_footer.initialize(); } }
+		]
+	}
+);
+```
+
+The ```title_footer.initialize``` function can take two parameters:
+
+- ```title```: the title to show in the footer; if ```null```, it will take the ```h1```, ```h2``` and ```h3``` elements of the first slide.
+- ```background```: a string of the form ```'rgba(0,255,0,0.1)'```, for the background colour of the footer.
+
 ## Installation
 
 The **basic setup** is for authoring presentations only. The **full setup** gives you access to all reveal.js features and plugins such as speaker notes as well as the development tasks needed to make changes to the source.

--- a/plugin/title-footer/title-footer.css
+++ b/plugin/title-footer/title-footer.css
@@ -1,0 +1,79 @@
+/*************************************************
+*                                                *
+* CSS for the Title-Footer plugin for Reveal.js  *
+*                                                *
+* Author: Igor Leturia                           *
+*                                                *
+* License: GPL v3                                *
+* http://www.gnu.org/copyleft/gpl.html           *
+*                                                *
+*************************************************/
+
+/* Style for the Title-Footer footer */
+
+#title-footer
+{
+	opacity: 1;
+	transition: opacity 800ms ease-in-out;
+	position: fixed;
+	height: 2vh;
+	z-index: 20;
+	width: 100%;
+	font-size: 2vh;
+	text-align: center;
+	letter-spacing: 0em;
+	padding-top: 0.5vh;
+	padding-bottom: 0.5vh;
+}
+
+/* Bottom position for the Title-Footer footer when both progress bar and TOC-Progress are visible */
+
+div.progress[style="display: block;"] ~ #title-footer
+{
+	bottom: calc(3px + 10.5vh);
+}
+
+/* Bottom position for the Title-Footer footer when TOC-Progress is visible */
+
+#title-footer
+{
+	bottom: 10.5vh;
+}
+
+/* Bottom position for the Title-Footer footer when progress bar is visible */
+
+div.progress[style="display: block;"] ~ footer:last-of-type#title-footer
+{
+	bottom: 3px;
+}
+
+/* Bottom position for the Title-Footer footer when neither progress bar nor TOC-Progress are visible */
+
+footer:last-of-type#title-footer
+{
+	bottom: 0px;
+}
+
+/* Make Title-Footer invisible if explicitly indicated */
+
+.no-title-footer #title-footer
+{
+	opacity: 0;
+	transition: opacity 800ms ease-in-out;
+}
+
+.no-toc-progress #title-footer
+{
+	opacity: 0;
+	transition: opacity 800ms ease-in-out;
+}
+
+/* Make Title-Footer invisible in overview mode */
+
+.overview #title-footer
+{
+	opacity: 0;
+	transition: opacity 800ms ease-in-out;
+}
+
+

--- a/plugin/title-footer/title-footer.js
+++ b/plugin/title-footer/title-footer.js
@@ -1,0 +1,117 @@
+/********************************************************
+*                                                       *
+* Javascript for the Title-Footer plugin for Reveal.js  *
+*                                                       *
+* Author: Igor Leturia                                  *
+*                                                       *
+* License: GPL v3                                       *
+* http://www.gnu.org/copyleft/gpl.html        *
+*                                                       *
+********************************************************/
+
+/* Title-Footer object and properties declaration with default values */
+
+var title_footer=
+{
+	title: '',
+	background:'rgba(0,0,0,0.1)',
+};
+
+/* Function to obtain all child elements with any of the indicated tags (from http://www.quirksmode.org/dom/getElementsByTagNames.html) */
+
+title_footer.getElementsByTagNames=function(list,obj)
+{
+	if (!obj)
+	{
+		var obj=document;
+	};
+	var tagNames=list.split(',');
+	var resultArray=new Array();
+	for (var i=0;i<tagNames.length;i++)
+	{
+		var tags=obj.getElementsByTagName(tagNames[i]);
+		for (var j=0;j<tags.length;j++)
+		{
+			resultArray.push(tags[j]);
+		};
+	};
+	var testNode=resultArray[0];
+	if (!testNode)
+	{
+		return [];
+	};
+	if (testNode.sourceIndex)
+	{
+		resultArray.sort(
+			function (a,b)
+			{
+				return a.sourceIndex-b.sourceIndex;
+			}
+		);
+	}
+	else if (testNode.compareDocumentPosition)
+	{
+		resultArray.sort(
+			function (a,b)
+			{
+				return 3-(a.compareDocumentPosition(b)&6);
+			}
+		);
+	};
+	return resultArray;
+};
+
+/* Method to initialize the Title-Footer footer */
+
+title_footer.initialize=function(title,background)
+{
+
+	// Link to the Title-Footer CSS
+
+	var link=document.createElement("link");
+	link.href="plugin/title-footer/title-footer.css";
+	link.type="text/css";
+	link.rel="stylesheet";
+	document.getElementsByTagName("head")[0].appendChild(link);
+
+	// Initialize properties according to parameters
+
+	this.background=background || 'rgba(0,0,0,0.1)';
+	var title=title || '';
+	if (title!='')
+	{
+		this.title=title;
+	}
+	else
+	{
+		var first_section=document.getElementsByTagName('section')[0];
+		if (first_section.getElementsByTagName('section').length>0)
+		{
+			first_section=first_section.getElementsByTagName('section')[0];
+		};
+		var title_elements=this.getElementsByTagNames('h1,h2,h3',first_section);
+		if (title_elements.length>0)
+		{
+			this.title=title_elements[0].textContent;
+			for (var title_elements_index=1;title_elements_index<title_elements.length;title_elements_index++)
+			{
+				this.title=this.title+' - '+title_elements[title_elements_index].textContent;
+			};
+		};
+	};
+
+	// Create the Title-Footer footer
+
+	var title_footer=document.createElement('footer');
+	title_footer.setAttribute('id','title-footer');
+	title_footer.setAttribute('style','background:'+this.background);
+	var title_footer_p=document.createElement('p');
+	title_footer.appendChild(title_footer_p);
+	var a_element=document.createElement('a');
+	a_element.setAttribute('href','#/0');
+	a_element.appendChild(document.createTextNode(this.title));
+	title_footer_p.appendChild(a_element);
+	var div_class_reveal=document.querySelectorAll('.reveal')[0];
+	div_class_reveal.appendChild(title_footer);
+};
+


### PR DESCRIPTION
This plugin includes a footer in all the slides (with optional exclusion of some slides) showing the title of the presentation. It takes the first ```h1```, ```h2``` and ```h3``` tags from the first slide as the title, if another title is not explicitly passed as parameter in the initialization. The title footer will not be shown in a slide if the corresponding section has a ```data-state``` attribute with a value of ```no-title-footer```. You can find an example of it working at [http://e-gor.github.io/Reveal.js-Title-Footer/demo](http://e-gor.github.io/Reveal.js-Title-Footer/demo) and instructions of use at [https://github.com/e-gor/Reveal.js-Title-Footer](https://github.com/e-gor/Reveal.js-Title-Footer).

Example configuration:

```javascript
Reveal.initialize
(
	{
		...
		dependencies:
		[
			...
			{ src: 'plugin/title-footer/title-footer.js', async: true, callback: function() { title_footer.initialize(); } }
		]
	}
);
```

The ```title_footer.initialize``` function can take two parameters:

- ```title```: the title to show in the footer; if ```null```, it will take the ```h1```, ```h2``` and ```h3``` elements of the first slide.
- ```background```: a string of the form ```'rgba(0,255,0,0.1)'```, for the background colour of the footer.
