### PR TITLE
Display speaker notes on PDF print-outs

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -52,14 +52,15 @@ html {
 /* SECTION 3: Set body font face, size, and color.
    Consider using a serif font for readability. */
 body, p, td, li, div {
-	font-size: 18pt;
+	font-size: 16pt !important;
 }
 
 /* SECTION 4: Set heading font face, sizes, and color.
    Differentiate your headings from your body text.
    Perhaps use a large sans-serif for distinction. */
-h1,h2,h3,h4,h5,h6 {
+.reveal h1, .reveal h2, .reveal h3,h4,h5,h6 {
 	text-shadow: 0 0 0 #000 !important;
+  font-size: 18pt;
 }
 
 /* SECTION 5: Make hyperlinks more usable.
@@ -118,12 +119,11 @@ ul, ol, div, p {
 	        perspective-origin: 50% 50%;
 }
 .reveal .slides section {
-
 	page-break-after: always !important;
 
 	visibility: visible !important;
 	position: relative !important;
-	width: 100% !important;
+	width: 279mm !important;
 	height: 229mm !important;
 	min-height: 229mm !important;
 	display: block !important;
@@ -132,7 +132,7 @@ ul, ol, div, p {
 	left: 0 !important;
 	top: 0 !important;
 	margin: 0 !important;
-	padding: 2cm 2cm 0 2cm !important;
+	padding: 2cm 10cm 0 2cm !important;
 	box-sizing: border-box !important;
 
 	opacity: 1 !important;
@@ -187,4 +187,25 @@ ul, ol, div, p {
 }
 .reveal small a {
 	font-size: 16pt !important;
+}
+.reveal aside.notes {
+  background:#FFF5B5;
+  border: 1px solid #E5D79E;
+  display: block !important;
+  font-size: 16pt;
+  line-height: 1.2em;
+  height: 190mm;
+  padding: 4mm;
+  position:absolute;
+  right: 0;
+  text-align: left;
+  top: 10mm;
+  width: 8cm;
+}
+.reveal a:link:after, .reveal a:visited:after {
+  content:" [" attr(href) "] ";
+  display: block;
+}
+.reveal aside.notes a:link:after, .reveal aside.notes a:visited:after {
+  content:"" !important;
 }


### PR DESCRIPTION
When creating a PDF of my deck I wanted the speaker notes to be available as well. I added the following CSS to `css/print/pdf.css`:

       191 .reveal aside.notes {
       192   border-top: 1px solid black;
       193   display: block !important;
       194   font-size: 16pt;
       195   height: 100%;
       196   line-height: 1.2em;
       197   margin-top: 60px;
       198   text-align: left;
       199 }

It worked well for my needs except on one or two slides where the region wasn't quite tall enough. I tried playing with the `section` visibility, but this didn't seem to make a difference. Suggestions on styles which would make all speaker notes display would be much appreciated (or if I'm approaching this the wrong way, suggestions on how to do this).

Slides with a problem:
![clipped](https://cloud.githubusercontent.com/assets/1299320/3419698/40a9244e-fe74-11e3-8661-d7bae3abf8bb.png)
![clipped-2](https://cloud.githubusercontent.com/assets/1299320/3419711/ec9e0dc8-fe74-11e3-859c-859c616625a4.png)

Slides without a problem:
![notclipped-2](https://cloud.githubusercontent.com/assets/1299320/3419709/cd57745e-fe74-11e3-8f12-9e33e2ec2d72.png)
![notclipped](https://cloud.githubusercontent.com/assets/1299320/3419697/40a75394-fe74-11e3-8931-4f6ba5cdd613.png)

