### PR TITLE
Use data-fragment-index for getIndices()

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2861,8 +2861,19 @@
 		if( !slide && currentSlide ) {
 			var hasFragments = currentSlide.querySelectorAll( '.fragment' ).length > 0;
 			if( hasFragments ) {
-				var visibleFragments = currentSlide.querySelectorAll( '.fragment.visible' );
-				f = visibleFragments.length - 1;
+				var currentFragment = currentSlide.querySelectorAll( '.current-fragment' );
+				if( currentFragment.length > 0 ) {
+					currentFragment = currentFragment[0];
+					var dataIndex = currentFragment.getAttribute( 'data-fragment-index' );
+					if( dataIndex && /^[0-9]+$/.test( dataIndex ) ) {
+						f = parseInt( dataIndex );
+					}
+				}
+				
+				if( !f ) {
+					var visibleFragments = currentSlide.querySelectorAll( '.fragment.visible' );
+					f = visibleFragments.length - 1;
+				}
 			}
 		}
 


### PR DESCRIPTION
A small patch to use the `data-fragment-index` as the returned index when it is available. This also allows `getIndices()` to return the right index when `data-fragment-index` is used with more than one of the same index. If the attribute is not found or the `data-fragment-index`is not a number, the normal method is used to find the index.
