### PR TITLE
added hostname option for grunt server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /* global module:false */
 module.exports = function(grunt) {
 	var port = grunt.option('port') || 8000;
+	var hostname = grunt.option('hostname') || 'localhost';
 	// Project configuration
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
@@ -80,7 +81,8 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
-					base: '.'
+					base: '.',
+					hostname: hostname
 				}
 			}
 		},


### PR DESCRIPTION
I am running reveal.js in a Vagrant box/VM. However it's not possible to access the server from my host system by just calling `grunt serve`. Only localhost connections are successful.
In order to be able to access from "everywhere", I needed a new hostname option in the Grunt configuration which is then forwarded to the `grunt-connect module (same workflow like the`port` option).
