### PR TITLE
Fixed incorrect CSS

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -56,6 +56,7 @@ body {
 	line-height: 1;
 }
 
+::-moz-selection,
 ::selection {
 	background: #FF5E99;
 	color: #fff;
@@ -479,7 +480,7 @@ body {
 }
 	.reveal .progress:after {
 		content: '';
-		display: 'block';
+		display: block;
 		position: absolute;
 		height: 20px;
 		width: 100%;
@@ -641,7 +642,7 @@ body {
 .reveal.center,
 .reveal.center .slides,
 .reveal.center .slides section {
-	min-height: auto !important;
+	min-height: 0 !important;
 }
 
 /* Don't allow interaction with invisible slides */
@@ -866,7 +867,7 @@ body {
 	        box-sizing: border-box;
 }
 	.reveal.center.cube .slides section {
-		min-height: auto;
+		min-height: 0;
 	}
 	.reveal.cube .slides section:not(.stack):before {
 		content: '';
@@ -1232,7 +1233,7 @@ body {
 	opacity: 1 !important;
 	position: relative !important;
 	height: auto;
-	min-height: auto;
+	min-height: 0;
 	top: 0;
 	left: -50%;
 	margin: 70px 0;


### PR DESCRIPTION
'min-height' doesn't support 'auto' as value, 'block' needs to be written without single quotes and '::selection' is prefixed in Gecko.
