### PR TITLE
Enable `data-preview-link` on anchor tags with nested elements

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3033,7 +3033,7 @@ var Reveal = (function(){
 	 */
 	function onPreviewLinkClicked( event ) {
 
-		var url = event.target.getAttribute( 'href' );
+		var url = event.currentTarget.getAttribute( 'href' );
 		if( url ) {
 			openPreview( url );
 			event.preventDefault();


### PR DESCRIPTION
Without this change, `data-preview-link` only works on `<a>`s with no child elements.

e.g.

``` html
    <a href="http://foo.bar" data-preview-link="true"><img src="kitten.jpg"></a>
```

does not open the link in a preview iframe because `event.target` is the child `<img>`.
