### PR TITLE
Enabled live-reload when changing index.html

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,8 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
-					base: '.'
+					base: '.',
+					livereload: true
 				}
 			}
 		},
@@ -104,6 +105,10 @@ module.exports = function(grunt) {
 			theme: {
 				files: [ 'css/theme/source/*.scss', 'css/theme/template/*.scss' ],
 				tasks: 'themes'
+			},
+			livereload: {
+				options: {livereload: true},
+				files: ['index.html']
 			}
 		}
 


### PR DESCRIPTION
I've added a change to the  Gruntfile so that editing index.html causes the browser page to reload (when `grunt connect watch` is running).