### PR TITLE
Fixed reload of slide with a custom ID containg special character

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2174,7 +2174,7 @@ var Reveal = (function(){
 		// assume that this is a named link
 		if( isNaN( parseInt( bits[0], 10 ) ) && name.length ) {
 			// Find the slide with the specified name
-			var element = document.querySelector( '#' + name );
+			var element = document.getElementById( name );
 
 			if( element ) {
 				// Find the position of the named slide and navigate to it


### PR DESCRIPTION
In ID selector some reserved characters like ., #, {, }, ... must be
escaped. It's easier to use getElementById() method which doesn't require escaping.

The current reveal.js will not reload deck at specified slide if it has ID containing for example period, like <section id="R1.2.3"> - this will be turned into #R1.2.3 selector, which is invalid.

Some issues and complexities of escaping CSS identifiers are availabe here https://mathiasbynens.be/notes/css-escapes