### PR TITLE
base option is configurable in grunt connect task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /* global module:false */
 module.exports = function(grunt) {
 	var port = grunt.option('port') || 8000;
+	var base = grunt.option('serve-base') || '.';
 	// Project configuration
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
@@ -95,9 +96,9 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
-					base: '.',
-                    livereload: true,
-                    open: true
+					base: base,
+					livereload: true,
+					open: true
 				}
 			}
 		},
@@ -114,9 +115,9 @@ module.exports = function(grunt) {
 		},
 
 		watch: {
-            options: {
-                livereload: true
-            },
+			options: {
+				livereload: true
+			},
 			js: {
 				files: [ 'Gruntfile.js', 'js/reveal.js' ],
 				tasks: 'js'
@@ -129,9 +130,9 @@ module.exports = function(grunt) {
 				files: [ 'css/reveal.scss' ],
 				tasks: 'css-core'
 			},
-            html: {
-                files: [ 'index.html']
-            }
+			html: {
+				files: [ 'index.html']
+			}
 		}
 
 	});


### PR DESCRIPTION
I'm using reveal.js core as a submodule in my project. This approach is nice because I don't have to store reveal.js core in my repo: https://github.com/CodeCarrotsJS/szkielet-prezentacji. But problem reveals when I want to run reveal.js server using `grunt serve` command in submodule directory(src/reveal.js). What I see is that `base` option is hardcoded to `.` I made it configurable to be able to run `grunt serve --serve-base=../..`.