### PR TITLE
Adding one-sided transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ Reveal.initialize({
 Read MathJax's documentation if you need [HTTPS delivery](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn) or serving of [specific versions](http://docs.mathjax.org/en/latest/configuration.html#loading-mathjax-from-the-cdn) for stability.
 
 
-## Installation
+## Installation<a id="installation"></a>
 
 The **basic setup** is for authoring presentations only. The **full setup** gives you access to all reveal.js features and plugins such as speaker notes as well as the development tasks needed to make changes to the source.
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,27 @@ The global presentation transition is set using the ```transition``` config valu
 </section>
 ```
 
+You can as well override only the appearing or the disappearing of the slide:
+
+```html
+<section data-transition="slide">
+    The train goes on … 
+</section>
+<section data-transition="slide"> 
+    and on … 
+</section>
+<section data-transition="slide-in fade-out"> 
+    and stops.
+</section>
+<section data-transition="fade-in slide-out"> 
+    (Passengers entering and leaving)
+</section>
+<section data-transition="slide">
+    And it starts again.
+</section>
+```
+
+
 Note that this does not work with the page and cube transitions.
 
 

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -447,93 +447,98 @@ body {
 
 
 /*********************************************
+ * Mixins for readability of transitions
+ *********************************************/
+
+@mixin transition-global($style) {
+  .reveal .slides>section[data-transition=#{$style}],
+  .reveal.#{$style} .slides>section:not([data-transition]) {
+    @content;
+  }
+}
+@mixin transition-horizontal-past($style) {
+  .reveal .slides>section[data-transition=#{$style}].past,
+  .reveal.#{$style} .slides>section:not([data-transition]).past {
+    @content;
+  }
+}
+@mixin transition-horizontal-future($style) {
+  .reveal .slides>section[data-transition=#{$style}].future,
+  .reveal.#{$style} .slides>section:not([data-transition]).future {
+    @content;
+  }
+}
+
+@mixin transition-vertical-past($style) {
+  .reveal .slides>section>section[data-transition=#{$style}].past,
+  .reveal.#{$style} .slides>section>section:not([data-transition]).past {
+    @content;
+  }
+}
+@mixin transition-vertical-future($style) {
+  .reveal .slides>section>section[data-transition=#{$style}].future,
+  .reveal.#{$style} .slides>section>section:not([data-transition]).future {
+    @content;
+  }
+}
+
+/*********************************************
  * SLIDE TRANSITION
  * Aliased 'linear' for backwards compatibility
  *********************************************/
 
-.reveal.slide section,
-.reveal.linear section {
-	backface-visibility: hidden;
+@each $stylename in slide, linear {
+	.reveal.#{$stylename} section {
+		backface-visibility: hidden;
+	}
+	@include transition-horizontal-past(#{$stylename}) {
+		transform: translate(-150%, 0);
+	}
+	@include transition-horizontal-future(#{$stylename}) {
+		transform: translate(150%, 0);
+	}
+	@include transition-vertical-past(#{$stylename}) {
+		transform: translate(0, -150%);
+	}
+	@include transition-vertical-future(#{$stylename}) {
+		transform: translate(0, 150%);
+	}
 }
-
-.reveal .slides>section[data-transition=slide].past,
-.reveal.slide .slides>section:not([data-transition]).past,
-.reveal .slides>section[data-transition=linear].past,
-.reveal.linear .slides>section:not([data-transition]).past {
-	transform: translate(-150%, 0);
-}
-.reveal .slides>section[data-transition=slide].future,
-.reveal.slide .slides>section:not([data-transition]).future,
-.reveal .slides>section[data-transition=linear].future,
-.reveal.linear .slides>section:not([data-transition]).future {
-	transform: translate(150%, 0);
-}
-
-.reveal .slides>section>section[data-transition=slide].past,
-.reveal.slide .slides>section>section:not([data-transition]).past,
-.reveal .slides>section>section[data-transition=linear].past,
-.reveal.linear .slides>section>section:not([data-transition]).past {
-	transform: translate(0, -150%);
-}
-.reveal .slides>section>section[data-transition=slide].future,
-.reveal.slide .slides>section>section:not([data-transition]).future,
-.reveal .slides>section>section[data-transition=linear].future,
-.reveal.linear .slides>section>section:not([data-transition]).future {
-	transform: translate(0, 150%);
-}
-
 
 /*********************************************
  * CONVEX TRANSITION
  * Aliased 'default' for backwards compatibility
  *********************************************/
 
-.reveal .slides>section[data-transition=default].past,
-.reveal.default .slides>section:not([data-transition]).past,
-.reveal .slides>section[data-transition=convex].past,
-.reveal.convex .slides>section:not([data-transition]).past {
-	transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
+@each $stylename in default, convex {
+	@include transition-horizontal-past(#{$stylename}) {
+		transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
+	}
+	@include transition-horizontal-future(#{$stylename}) {
+		transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
+	}
+	@include transition-vertical-past(#{$stylename}) {
+		transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
+	}
+	@include transition-vertical-future(#{$stylename}) {
+		transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
+	}
 }
-.reveal .slides>section[data-transition=default].future,
-.reveal.default .slides>section:not([data-transition]).future,
-.reveal .slides>section[data-transition=convex].future,
-.reveal.convex .slides>section:not([data-transition]).future {
-	transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
-}
-
-.reveal .slides>section>section[data-transition=default].past,
-.reveal.default .slides>section>section:not([data-transition]).past,
-.reveal .slides>section>section[data-transition=convex].past,
-.reveal.convex .slides>section>section:not([data-transition]).past {
-	transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
-}
-.reveal .slides>section>section[data-transition=default].future,
-.reveal.default .slides>section>section:not([data-transition]).future,
-.reveal .slides>section>section[data-transition=convex].future,
-.reveal.convex .slides>section>section:not([data-transition]).future {
-	transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
-}
-
 
 /*********************************************
  * CONCAVE TRANSITION
  *********************************************/
 
-.reveal .slides>section[data-transition=concave].past,
-.reveal.concave .slides>section:not([data-transition]).past {
+@include transition-horizontal-past(concave) {
 	transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0);
 }
-.reveal .slides>section[data-transition=concave].future,
-.reveal.concave .slides>section:not([data-transition]).future {
+@include transition-horizontal-future(concave) {
 	transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0);
 }
-
-.reveal .slides>section>section[data-transition=concave].past,
-.reveal.concave .slides>section>section:not([data-transition]).past {
+@include transition-vertical-past(concave) {
 	transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0);
 }
-.reveal .slides>section>section[data-transition=concave].future,
-.reveal.concave .slides>section>section:not([data-transition]).future {
+@include transition-vertical-future(concave) {
 	transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0);
 }
 
@@ -542,29 +547,22 @@ body {
  * ZOOM TRANSITION
  *********************************************/
 
-.reveal .slides>section[data-transition=zoom],
-.reveal.zoom .slides>section:not([data-transition]) {
-	transition-timing-function: ease;
+@include transition-global(zoom) {
+  transition-timing-function: ease;
 }
-
-.reveal .slides>section[data-transition=zoom].past,
-.reveal.zoom .slides>section:not([data-transition]).past {
-	visibility: hidden;
-	transform: scale(16);
+@include transition-horizontal-past(zoom) {
+  visibility: hidden;
+  transform: scale(16);
 }
-.reveal .slides>section[data-transition=zoom].future,
-.reveal.zoom .slides>section:not([data-transition]).future {
-	visibility: hidden;
-	transform: scale(0.2);
+@include transition-horizontal-future(zoom) {
+  visibility: hidden;
+  transform: scale(0.2);
 }
-
-.reveal .slides>section>section[data-transition=zoom].past,
-.reveal.zoom .slides>section>section:not([data-transition]).past {
-	transform: translate(0, -150%);
+@include transition-vertical-past(zoom) {
+  transform: translate(0, -150%);
 }
-.reveal .slides>section>section[data-transition=zoom].future,
-.reveal.zoom .slides>section>section:not([data-transition]).future {
-	transform: translate(0, 150%);
+@include transition-vertical-future(zoom) {
+  transform: translate(0, 150%);
 }
 
 
@@ -732,8 +730,7 @@ body {
  * NO TRANSITION
  *********************************************/
 
-.reveal .slides section[data-transition=none],
-.reveal.none .slides section:not([data-transition]) {
+@include transition-global(none) {
 	transform: none;
 	transition: none;
 }

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -458,12 +458,14 @@ body {
 }
 @mixin transition-horizontal-past($style) {
   .reveal .slides>section[data-transition=#{$style}].past,
+  .reveal .slides>section[data-transition~=#{$style}-out].past,
   .reveal.#{$style} .slides>section:not([data-transition]).past {
     @content;
   }
 }
 @mixin transition-horizontal-future($style) {
   .reveal .slides>section[data-transition=#{$style}].future,
+  .reveal .slides>section[data-transition~=#{$style}-in].future,
   .reveal.#{$style} .slides>section:not([data-transition]).future {
     @content;
   }
@@ -471,12 +473,14 @@ body {
 
 @mixin transition-vertical-past($style) {
   .reveal .slides>section>section[data-transition=#{$style}].past,
+  .reveal .slides>section>section[data-transition~=#{$style}-out].past,
   .reveal.#{$style} .slides>section>section:not([data-transition]).past {
     @content;
   }
 }
 @mixin transition-vertical-future($style) {
   .reveal .slides>section>section[data-transition=#{$style}].future,
+  .reveal .slides>section>section[data-transition~=#{$style}-in].future,
   .reveal.#{$style} .slides>section>section:not([data-transition]).future {
     @content;
   }


### PR DESCRIPTION
Now the transition isn’t any more „per slide“ but „per movement of a slide“. So the slide can disappear in a different way than it appeared. This makes a more natural changing of the transition style during a talk.
There is an explanation added to README.md.

(This is my first pull request ever, so please be kind if I made any mistakes.)