### PR TITLE
Contained deployment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 /* global module:false */
 module.exports = function(grunt) {
+	var hostname = grunt.option('hostname') || 'localhost';
 	var port = grunt.option('port') || 8000;
 	// Project configuration
 	grunt.initConfig({
@@ -94,6 +95,7 @@ module.exports = function(grunt) {
 		connect: {
 			server: {
 				options: {
+					hostname: hostname,
 					port: port,
 					base: '.',
                     livereload: true,

--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ The multiplex plugin needs the following 3 things to operate:
 More details:
 
 #### Master presentation
-Served from a static file server accessible (preferably) only to the presenter. This need only be on your (the presenter's) computer. (It's safer to run the master presentation from your own computer, so if the venue's Internet goes down it doesn't stop the show.) An example would be to execute the following commands in the directory of your master presentation: 
+Served from a static file server accessible (preferably) only to the presenter. This need only be on your (the presenter's) computer. (It's safer to run the master presentation from your own computer, so if the venue's Internet goes down it doesn't stop the show.) An example would be to execute the following commands in the directory of your master presentation:
 
 1. ```npm install node-static```
 2. ```static```
@@ -830,7 +830,7 @@ You are very welcome to point your presentations at the Socket.io server running
 
 ##### socket.io server as file static server
 
-The socket.io server can play the role of static file server for your client presentation, as in the example at [http://revealjs.jit.su](http://revealjs.jit.su). (Open [http://revealjs.jit.su](http://revealjs.jit.su) in two browsers. Navigate through the slides on one, and the other will update to match.) 
+The socket.io server can play the role of static file server for your client presentation, as in the example at [http://revealjs.jit.su](http://revealjs.jit.su). (Open [http://revealjs.jit.su](http://revealjs.jit.su) in two browsers. Navigate through the slides on one, and the other will update to match.)
 
 Example configuration:
 ```javascript
@@ -927,7 +927,7 @@ Reveal.initialize({
 
 If you want to display math equations in your presentation you can easily do so by including this plugin. The plugin is a very thin wrapper around the [MathJax](http://www.mathjax.org/) library. To use it you'll need to include it as a reveal.js dependency, [find our more about dependencies here](#dependencies).
 
-The plugin defaults to using [LaTeX](http://en.wikipedia.org/wiki/LaTeX) but that can be adjusted through the ```math``` configuration object. Note that MathJax is loaded from a remote server. If you want to use it offline you'll need to download a copy of the library and adjust the ```mathjax``` configuration value. 
+The plugin defaults to using [LaTeX](http://en.wikipedia.org/wiki/LaTeX) but that can be adjusted through the ```math``` configuration object. Note that MathJax is loaded from a remote server. If you want to use it offline you'll need to download a copy of the library and adjust the ```mathjax``` configuration value.
 
 Below is an example of how the plugin can be configured. If you don't intend to change these values you do not need to include the ```math``` config object at all.
 
@@ -940,7 +940,7 @@ Reveal.initialize({
 		mathjax: 'http://cdn.mathjax.org/mathjax/latest/MathJax.js',
 		config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
 	},
-	
+
 	dependencies: [
 		{ src: 'plugin/math/math.js', async: true }
 	]
@@ -972,31 +972,29 @@ Some reveal.js features, like external Markdown and speaker notes, require that 
 
 1. Install [Node.js](http://nodejs.org/)
 
-2. Install [Grunt](http://gruntjs.com/getting-started#installing-the-cli)
-
-4. Clone the reveal.js repository
+2. Clone the reveal.js repository
    ```sh
    $ git clone https://github.com/hakimel/reveal.js.git
    ```
 
-5. Navigate to the reveal.js folder
+3. Navigate to the reveal.js folder
    ```sh
    $ cd reveal.js
    ```
 
-6. Install dependencies
+4. Install dependencies
    ```sh
    $ npm install
    ```
 
-7. Serve the presentation and monitor source files for changes
+5. Serve the presentation and monitor source files for changes
    ```sh
-   $ grunt serve
+   $ node_modules/.bin/grunt serve
    ```
 
-8. Open <http://localhost:8000> to view your presentation
+6. Open <http://localhost:8000> to view your presentation
 
-   You can change the port by using `grunt serve --port 8001`.
+   You can change the port by using `--port 8001`.
 
 
 ### Folder Structure

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-connect": "~0.8.0",
     "grunt-autoprefixer": "~1.0.1",
     "grunt-zip": "~0.7.0",
+    "grunt-cli": "~0.1.13",
     "grunt": "~0.4.0",
     "node-sass": "~0.9.3"
   },


### PR DESCRIPTION
This adds `grunt-cli` to `devDependencies` so it is not mandatory to install `grunt-cli` globally when running reveal.js.

Also this PR adds `--hostname` option to `grunt serve` command, so it is possible to set hostname to bind to.

With these two changes it becomes possible to deploy `reveal.js` to heroku by adding a `Procfile` with the following contents:

```
web: npm install && node_modules/.bin/grunt serve --hostname 0.0.0.0 --port $PORT
```

I've seen previous attempts (#801) of making reveal.js easier to deploy to heroku, and I apprieciate your goal of keeping reveal.js environment agnostic. IMO this change makes `reveal.js` self contained and allows for easier deployment to various environments.
