### PR TITLE
Check before calling blur on activeElement.

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3872,7 +3872,10 @@
 		// If, after clicking a link or similar and we're coming back,
 		// focus the document.body to ensure we can use keyboard shortcuts
 		if( isHidden === false && document.activeElement !== document.body ) {
-			document.activeElement.blur();
+			// Not all elements support .blur() - SVGs among them.
+			if (typeof document.activeElement.blur === 'function') {
+				document.activeElement.blur();
+			}
 			document.body.focus();
 		}
 


### PR DESCRIPTION
It's possible for slides to be in a situation where the last clicked thing was an SVG before the tab/window loses focus. When returning, `.blur()` is called on the previously-active element, but can result in an exception.

This protects against that and will only call `.blur()` when `document.activeElement` supports it.