### PR TITLE
Add support for custom notes.html file

### DIFF
--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -11,10 +11,14 @@
  */
 var RevealNotes = (function() {
 
-	function openNotes() {
-		var jsFileLocation = document.querySelector('script[src$="notes.js"]').src;  // this js file path
-		jsFileLocation = jsFileLocation.replace(/notes\.js(\?.*)?$/, '');   // the js folder path
-		var notesPopup = window.open( jsFileLocation + 'notes.html', 'reveal.js - Notes', 'width=1100,height=700' );
+	function openNotes(notes_html_file_path) {
+		if (!notes_html_file_path) {
+			var jsFileLocation = document.querySelector('script[src$="notes.js"]').src;  // this js file path
+			jsFileLocation = jsFileLocation.replace(/notes\.js(\?.*)?$/, '');   // the js folder path
+			notes_html_file_path = jsFileLocation + 'notes.html';
+		}
+			
+		var notesPopup = window.open(notes_html_file_path, 'reveal.js - Notes', 'width=1100,height=700' );
 
 		/**
 		 * Connect to the notes window through a postmessage handshake.


### PR DESCRIPTION
It would be nice if we could define a custom notes.html file.

Actually, I'm used to compile my js files before releasing my app and, using selectors like `script[src$="notes.js"]`, doesn't work :(

So, what do you think about it?