### PR TITLE
Make npm dependency usable by Browserify through NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The HTML Presentation Framework",
   "homepage": "http://lab.hakim.se/reveal-js",
   "subdomain": "revealjs",
+  "main": "js/reveal.js",
   "scripts": {
     "test": "grunt test",
     "start": ""


### PR DESCRIPTION
Right now the package is not recognized as usable library by Browserify.
Adding the main attribute in the package.json solves that, and now gives
others the possibility to use reveal as a library in more complex
systems.