### PR TITLE
support query parameters within notes plugin

### DIFF
--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -28,7 +28,7 @@ var RevealNotes = (function() {
 				notesPopup.postMessage( JSON.stringify( {
 					namespace: 'reveal-notes',
 					type: 'connect',
-					url: window.location.protocol + '//' + window.location.host + window.location.pathname,
+					url: window.location.protocol + '//' + window.location.host + window.location.pathname + window.location.search,
 					state: Reveal.getState()
 				} ), '*' );
 			}, 500 );


### PR DESCRIPTION
I'm dynamically injecting slide content via `?src=chapter.md` - previously such parameters were ignored for speaker notes, rendering them unusable

edit: unfortunately I failed to target the dev branch here - GitHub's UI doesn't seem to allow changing that