### PR TITLE
Display .stretch images in overview mode. Fix #1187

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1195,10 +1195,15 @@
 			// Change the .stretch element height to 0 in order find the height of all
 			// the other elements
 			element.style.height = '0px';
+			// In Overview mode, the parent (.slide) height is set of 700px.
+			// Restore it temporarily to its natural height.
+			element.parentNode.style.height = 'auto';
 			newHeight = height - element.parentNode.offsetHeight;
 
 			// Restore the old height, just in case
 			element.style.height = oldHeight + 'px';
+			// Clear the parent (.slide) height. .removeProperty works in IE9+
+			element.parentNode.style.removeProperty('height');
 
 			return newHeight;
 		}


### PR DESCRIPTION
The height of `.stretch` elements is computed by setting its height to 0 and comparing the height of the rest of the elements with the parent slide's height.

In Overview mode, the parent slide's height is set to `700px`. So setting the `.stretch` element's height to 0 has no impact on the parent's height. This results in the `.stretch` element _always having a zero height_.

This commit temporarily sets the parent slide's height to `auto` before computing the new height, and clears the height.
