### PR TITLE
Allow tex parsing in <code> tags

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -14,7 +14,10 @@ var RevealMath = window.RevealMath || (function(){
 
 		MathJax.Hub.Config({
 			messageStyle: 'none',
-			tex2jax: { inlineMath: [['$','$'],['\\(','\\)']] },
+			tex2jax: {
+				inlineMath: [['$','$'],['\\(','\\)']] ,
+				skipTags: ['script','noscript','style','textarea','pre']
+			},
 			skipStartupTypeset: true
 		});
 


### PR DESCRIPTION
This adresses #702.

Before: `$\sum_{m} \sum_{d}$`  
![screen shot 2015-04-16 at 13 38 26](https://cloud.githubusercontent.com/assets/3909961/7180037/0603d662-e43e-11e4-964f-f7a42a40cea3.png)

After: ``` `$\sum_{m} \sum_{d}$` ```  
![screen shot 2015-04-16 at 13 38 46](https://cloud.githubusercontent.com/assets/3909961/7180043/0f3cd666-e43e-11e4-96cc-d1027f8595a2.png)


Just using $ as delimiter in markdown document fails since the markdown
parser unknown to the dollar syntax will try to interpret underscores.
Putting the $ delimented formula in backticks will cause the markdown
parser to put the tex-code with the $ delimiters into a code block.
The texcode will then be unchanged. This patch allows for mathJax to
interpret and automagically display all tex-formulas.