### PR TITLE
Refactoring package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
   "engines": {
     "node": "~0.10.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "underscore": "~1.5.1",
     "express": "~2.5.9",
     "mustache": "~0.7.2",
-    "socket.io": "~0.9.16"
-  },
-  "devDependencies": {
+    "socket.io": "~0.9.16",
     "grunt-contrib-qunit": "~0.5.2",
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-cssmin": "~0.4.1",


### PR DESCRIPTION
On a Mac, you running npm install will not work if you have packages in
dependencies. Moving them to devdependencies fixes the issue. If you
leave them in devdependencies the following will occur:

    anpm WARN package.json node-sass@0.9.6 No bin file found at bin/node-sass
    npm WARN unmet dependency reveal.js/node_modules/grunt-sass requires node-sass@'0.9.3' but will load
    npm WARN unmet dependency reveal.js/node_modules/node-sass,
    npm WARN unmet dependency which is version 0.9.6
    npm WARN unmet dependency reveal.js/node_modules/grunt-contrib-qunit/node_modules/grunt-lib-phantomjs/node_modules/phantomjs/node_modules/npmconf requires semver@'2 || 3 || 4' but will load
    npm WARN unmet dependency reveal.js/node_modules/grunt-contrib-qunit/node_modules/grunt-lib-phantomjs/node_modules/semver,
    npm WARN unmet dependency which is version 1.0.14
    npm WARN unmet dependency reveal.js/node_modules/grunt-contrib-jshint/node_modules/jshint requires underscore@'1.4.x' but will load
    npm WARN unmet dependency reveal.js/node_modules/underscore,
    npm WARN unmet dependency which is version 1.5.2
    npm WARN unmet dependency reveal.js/node_modules/grunt/node_modules/findup-sync/node_modules/glob requires minimatch@'0.3' but will load
    npm WARN unmet dependency reveal.js/node_modules/grunt/node_modules/minimatch,
    npm WARN unmet dependency which is version 0.2.14

System:

Mac Book Pro 13 Retina Early 2015 running Yosemite 10.10.3
Node: v0.12.2
NPM:  2.7.5