### PR TITLE
Fix last row header having a border-bottom

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -199,8 +199,9 @@ body {
 	border-bottom: 1px solid;
 }
 
-.reveal table tr:last-child td {
-    border-bottom: none;
+.reveal table tbody tr:last-child th,
+.reveal table tbody tr:last-child td {
+	border-bottom: none;
 }
 
 .reveal sup {


### PR DESCRIPTION
`<tbody/>` is automatically inserted by the browser, so we can guarantee that this affects all ths and tds in the last row of the table *body* and the table head is left untouched.