### PR TITLE
add missing dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-sass": "~0.14.0",
     "grunt-contrib-connect": "~0.8.0",
+    "grunt-lib-contrib": "~0.3.0 ",
+    "node-sass-middleware": "~0.5.0",
     "grunt-autoprefixer": "~1.0.1",
     "grunt-zip": "~0.7.0",
     "grunt": "~0.4.0",


### PR DESCRIPTION
I saw errors after creating a clean fork and ran `grunt serve` command. So I added these two lines in package.json.