### PR TITLE
`licenses` field is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,6 @@
     "grunt": "~0.4.0",
     "node-sass": "~0.9.3"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/hakimel/reveal.js/blob/master/LICENSE"
-    }
-  ]
+  
+  "license": "MIT"
 }


### PR DESCRIPTION
the `licenses` field in package.json is deprecated. https://docs.npmjs.com/files/package.json#license

The `license` field is the recommended field and expects an SPDX expression.