### PR TITLE
README: suggest decktape as an alternative for PDF rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,8 @@ Here's an example of an exported presentation that's been uploaded to SlideShare
 
 ![Chrome Print Settings](https://s3.amazonaws.com/hakim-static/reveal-js/pdf-print-settings.png)
 
+Alternatively you can use the [decktape](https://github.com/astefanutti/decktape) project.
+
 ## Theming
 
 The framework comes with a few different themes included:


### PR DESCRIPTION
It works around the current PDF rendering bugs like #1261. I have experienced other PDF rendering issues where the text's vertical alignment varies from slide to slide. I guess it's just simpler to instrument a browser and where the decktape project shines is that they use a fork of phantomjs to fix issues where links were not properly kept in PDF renders.

I'm open to rewording of the sentence. At first I stated why it was a superior alternative for pixel perfect PDF rendering of the slides compared to the print-pdf option but decided that less text was better.

I enjoy reveal.js so much. Thanks for your work!
p.s.: for the record, I am not affiliated with decktape