### PR TITLE
solves early access error with video element

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2612,7 +2612,7 @@
 			// Start video playback
 			var currentVideo = currentBackground.querySelector( 'video' );
 			if( currentVideo ) {
-				currentVideo.currentTime = 0;
+				if(currentVideo.currentTime > 0) currentVideo.currentTime = 0;
 				currentVideo.play();
 			}
 


### PR DESCRIPTION
This will maybe solve the "InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable" error in firefox.