### PR TITLE
Update reveal.js

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3151,7 +3151,6 @@
 				// Attempt to create a named link based on the slide's ID
 				var id = currentSlide.getAttribute( 'id' );
 				if( id ) {
-					id = id.toLowerCase();
 					id = id.replace( /[^a-zA-Z0-9\-\_\:\.]/g, '' );
 				}
 


### PR DESCRIPTION
To address issue #1319, removed toLowerCase call which was added when fixing issue #836.  (Disallowing lowercase URLs does not appear to have been related to the original issue.)