### PR TITLE
Add autoplay support for asciinema

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2996,6 +2996,10 @@
 		else if( /player\.vimeo\.com\//.test( iframe.getAttribute( 'src' ) ) && iframe.hasAttribute( 'data-autoplay' ) ) {
 			iframe.contentWindow.postMessage( '{"method":"play"}', '*' );
 		}
+		// asciinema postMessage API
+		else if( /asciinema\.org\/api\/asciicasts\//.test( iframe.getAttribute( 'src' ) ) && iframe.hasAttribute( 'data-autoplay' ) ) {
+			iframe.contentWindow.postMessage( ['asciicast:play'], '*' );
+		}
 		// Generic postMessage API
 		else {
 			iframe.contentWindow.postMessage( 'slide:start', '*' );


### PR DESCRIPTION
[Asciinema](https://asciinema.org/) is a popular service allowing users to record terminal screencasts ("asciicasts") and play them back in a react.js based player, enabling easy after-the-fact manipulation of color themes, font size, playback speed etc.

Since asciinema/asciinema.org@2913c045, Asciinema supports an `asciicast:play` event that enables autoplay. Fix up reveal.js in the same way as previously for Vimeo and YouTube.

This patch should also apply cleanly to master.

For background, see also asciinema/asciinema.org#175.