### PR TITLE
Add more support for external markdown.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,7 +107,8 @@ module.exports = function(grunt) {
 				'js/**',
 				'lib/**',
 				'images/**',
-				'plugin/**'
+				'plugin/**',
+        '**.md'
 			]
 		},
 
@@ -129,7 +130,10 @@ module.exports = function(grunt) {
 			},
 			html: {
 				files: [ 'index.html']
-			}
+			},
+      markdown: {
+        files: [ './*.md' ]
+      }
 		}
 
 	});


### PR DESCRIPTION
The 'grunt watch' command now also watches for changes to external
markdown.
The 'grunt package' command now packages all external markdown files for
rapid deployment in static enviroments.