### PR TITLE
format note content when creating slide

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -117,7 +117,7 @@
 		var notesMatch = content.split( new RegExp( options.notesSeparator, 'mgi' ) );
 
 		if( notesMatch.length === 2 ) {
-			content = notesMatch[0] + '<aside class="notes" data-markdown>' + notesMatch[1].trim() + '</aside>';
+			content = notesMatch[0] + '<aside class="notes">' + marked(notesMatch[1].trim()) + '</aside>';
 		}
 
 		// prevent script end tags in the content from interfering


### PR DESCRIPTION
In html content, marked allow `Inline-Level Grammar` but not `Block-Level Grammar`, so when I write following:
```
note:
* a
* b
* c
```
it become:
```html
<p><em> a
</em> b</p>
<ul>
<li>c</li>
</ul>
```
unbelievable!