### PR TITLE
README - remove script tag from markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,15 @@ Markup hierarchy needs to be ``<div class="reveal"> <div class="slides"> <sectio
 
 ### Markdown
 
-It's possible to write your slides using Markdown. To enable Markdown, add the ```data-markdown``` attribute to your ```<section>``` elements and wrap the contents in a ```<script type="text/template">``` like the example below.
+It's possible to write your slides using Markdown. To enable Markdown, add the ```data-markdown``` attribute to your ```<section>``` element like the example below.
 
 This is based on [data-markdown](https://gist.github.com/1343518) from [Paul Irish](https://github.com/paulirish) modified to use [marked](https://github.com/chjj/marked) to support [Github Flavoured Markdown](https://help.github.com/articles/github-flavored-markdown). Sensitive to indentation (avoid mixing tabs and spaces) and line breaks (avoid consecutive breaks).
 
 ```html
 <section data-markdown>
-	<script type="text/template">
-		## Page title
+	## Page title
 
-		A paragraph with some text and a [link](http://hakim.se).
-	</script>
+	A paragraph with some text and a [link](http://hakim.se).
 </section>
 ```
 


### PR DESCRIPTION
\<script type="text/template"\> is not needed when using \<section data-markdown\> as
shown in index.html.