### PR TITLE
stops parallax failing if only the single horizontal slide and multiple vertical

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2798,7 +2798,7 @@
 				horizontalOffsetMultiplier = config.parallaxBackgroundHorizontal;
 			}
 			else {
-				horizontalOffsetMultiplier = ( backgroundWidth - slideWidth ) / ( horizontalSlideCount-1 );
+				horizontalOffsetMultiplier = ( horizontalSlideCount-1  > 0) ? ( backgroundWidth - slideWidth ) / ( horizontalSlideCount-1 ) : 0;
 			}
 
 			horizontalOffset = horizontalOffsetMultiplier * indexh * -1;


### PR DESCRIPTION
Check for 0 division, if so set to horizontalOffsetMultiplier to 0, this allows for presentation's that are all vertical slides