### PR TITLE
Fix misleading quotes for parallax config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Reveal.initialize({
 
 	// Amount to move parallax background (horizontal and vertical) on slide change
 	// Number, e.g. 100
-	parallaxBackgroundHorizontal: '',
-	parallaxBackgroundVertical: ''
+	parallaxBackgroundHorizontal: ,
+	parallaxBackgroundVertical: 
 
 });
 ```


### PR DESCRIPTION
As reveal.js expects an integer rather than a string, quotes should not be used.