### PR TITLE
Add an option to auto-slide right only

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ Reveal.initialize({
 	// Stop auto-sliding after user input
 	autoSlideStoppable: true,
 
+	// When auto-sliding is active, do always proceed to the right
+	// instead of the next slide which may be below (useful for
+	// infinite loop presentations with hidden "bonus slides")
+	autoSlideRight: false,
+
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,8 @@ Reveal.initialize({
 	// Stop auto-sliding after user input
 	autoSlideStoppable: true,
 
-	// When auto-sliding is active, do always proceed to the right
-	// instead of the next slide which may be below (useful for
-	// infinite loop presentations with hidden "bonus slides")
-	autoSlideRight: false,
+	// Use this method for navigation when auto-sliding
+	autoSlideMethod: Reveal.navigateNext,
 
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
@@ -301,6 +299,8 @@ You can also override the slide duration for individual slides and fragments by 
 	<p class="fragment">Now, the fragment is displayed for 2 seconds before the next slide is shown.</p>
 </section>
 ```
+
+To override the method used for navigation when auto-sliding, you can specify the ```autoSlideMethod``` setting. To only navigate along the top layer and ignore vertical slides, set this to ```Reveal.navigateRight```.
 
 Whenever the auto-slide mode is resumed or paused the ```autoslideresumed``` and ```autoslidepaused``` events are fired.
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -103,11 +103,6 @@
 			// Stop auto-sliding after user input
 			autoSlideStoppable: true,
 
-			// When auto-sliding is active, do always proceed to the right
-			// instead of the next slide which may be below (useful for
-			// infinite loop presentations with hidden "bonus slides")
-			autoSlideRight: false,
-
 			// Enable slide navigation via mouse wheel
 			mouseWheel: false,
 
@@ -3693,7 +3688,10 @@
 			// - The overview isn't active
 			// - The presentation isn't over
 			if( autoSlide && !autoSlidePaused && !isPaused() && !isOverview() && ( !Reveal.isLastSlide() || availableFragments().next || config.loop === true ) ) {
-				autoSlideTimeout = setTimeout( navigateNext, autoSlide );
+				autoSlideTimeout = setTimeout( function() {
+					typeof config.autoSlideMethod == 'function' ? config.autoSlideMethod() : navigateNext();
+					cueAutoSlide();
+				}, autoSlide );
 				autoSlideStartTime = Date.now();
 			}
 
@@ -3828,7 +3826,7 @@
 
 		// Prioritize revealing fragments
 		if( nextFragment() === false ) {
-			if( availableRoutes().down && !( autoSlide && config.autoSlideRight ) ) {
+			if( availableRoutes().down ) {
 				navigateDown();
 			}
 			else if( config.rtl ) {
@@ -3838,10 +3836,6 @@
 				navigateRight();
 			}
 		}
-
-		// If auto-sliding is enabled we need to cue up
-		// another timeout
-		cueAutoSlide();
 
 	}
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3689,7 +3689,7 @@
 			// - The presentation isn't over
 			if( autoSlide && !autoSlidePaused && !isPaused() && !isOverview() && ( !Reveal.isLastSlide() || availableFragments().next || config.loop === true ) ) {
 				autoSlideTimeout = setTimeout( function() {
-					typeof config.autoSlideMethod == 'function' ? config.autoSlideMethod() : navigateNext();
+					typeof config.autoSlideMethod === 'function' ? config.autoSlideMethod() : navigateNext();
 					cueAutoSlide();
 				}, autoSlide );
 				autoSlideStartTime = Date.now();

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -103,6 +103,11 @@
 			// Stop auto-sliding after user input
 			autoSlideStoppable: true,
 
+			// When auto-sliding is active, do always proceed to the right
+			// instead of the next slide which may be below (useful for
+			// infinite loop presentations with hidden "bonus slides")
+			autoSlideRight: false,
+
 			// Enable slide navigation via mouse wheel
 			mouseWheel: false,
 
@@ -3823,7 +3828,7 @@
 
 		// Prioritize revealing fragments
 		if( nextFragment() === false ) {
-			if( availableRoutes().down ) {
+			if( availableRoutes().down && !( autoSlide && config.autoSlideRight ) ) {
 				navigateDown();
 			}
 			else if( config.rtl ) {


### PR DESCRIPTION
I needed to prepare a presentation that runs automatically in an infinite loop with a few "bonus slides" that further explain certain topics within the presentation. However, auto-sliding per default always navigates to the next slide which may be below the current one.

With the autoSlideRight option enabled, auto-sliding will ignore the basement levels and always navigate to the right. However, the user can always intervene and seamlessly bring up the additional slides with the bonus content.