### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
-/test               export-ignore
-/bower.json         export-ignore
-/CONTRIBUTING.md    export-ignore
-/Gruntfile.js       export-ignore
-/package.json       export-ignore
+/css/theme/source       export-ignore
+/css/theme/template     export-ignore
+/css/theme/README.md    export-ignore
+/css/reveal.scss        export-ignore
+/test                   export-ignore
+/bower.json             export-ignore
+/CONTRIBUTING.md        export-ignore
+/Gruntfile.js           export-ignore
+/package.json           export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/test               export-ignore
+/bower.json         export-ignore
+/CONTRIBUTING.md    export-ignore
+/Gruntfile.js       export-ignore
+/package.json       export-ignore


### PR DESCRIPTION
[tl;dr](https://en.wikipedia.org/wiki/Wikipedia:Too_long;_didn%27t_read): When a release is pushed to Github, this will exclude files from the release archives that aren't needed if the user is not making changes to reveal.js itself, e.g. doing a custom build.

See [this Reddit thread](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/) for more information.
