### PR TITLE
Chromium users need to check Background graphics option when printing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,8 @@ Here's an example of an exported presentation that's been uploaded to SlideShare
 3. Change the **Destination** setting to **Save as PDF**.
 4. Change the **Layout** to **Landscape**.
 5. Change the **Margins** to **None**.
-6. Click **Save**.
+6. (Under Chromium) In **Options** check **Background graphics**.
+7. Click **Save**.
 
 ![Chrome Print Settings](https://s3.amazonaws.com/hakim-static/reveal-js/pdf-print-settings.png)
 


### PR DESCRIPTION
I have tried printing my slides as PDF today and I was wondering why the hell all of my slides are white. Turns out you need to check **Background graphics** option in Chromium when printing.