### PR TITLE
Set asynchronous load of external markdown

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -205,7 +205,7 @@
 	 * multi-slide markdown into separate sections and
 	 * handles loading of external markdown.
 	 */
-	function processSlides() {
+	function processSlides(callback) {
 
 		var sections = document.querySelectorAll( '[data-markdown]'),
 			section;
@@ -251,7 +251,8 @@
 					}
 				};
 
-				xhr.open( 'GET', url, false );
+				xhr.onload = callback
+				xhr.open( 'GET', url, true );
 
 				try {
 					xhr.send();
@@ -268,8 +269,8 @@
 					verticalSeparator: section.getAttribute( 'data-separator-vertical' ),
 					notesSeparator: section.getAttribute( 'data-separator-notes' ),
 					attributes: getForwardedAttributes( section )
-				});
 
+				});
 			}
 			else {
 				section.innerHTML = createMarkdownSlide( getMarkdownFromSlide( section ) );
@@ -388,8 +389,11 @@
 	return {
 
 		initialize: function() {
-			processSlides();
-			convertSlides();
+			processSlides(function() {
+				convertSlides();
+				Reveal.sync();
+				Reveal.slide(0);
+			});
 		},
 
 		// TODO: Do these belong in the API?


### PR DESCRIPTION
Set xhr.open as asynchronous while loading an external markdown file.
This fixes https://github.com/astefanutti/decktape/issues/12 which then resolves all pdf-export problems.