### PR TITLE
Add "background div" to allow HTML backgrounds

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2870,7 +2870,8 @@
 				var backgroundImage = slide.getAttribute( 'data-background-image' ),
 					backgroundVideo = slide.getAttribute( 'data-background-video' ),
 					backgroundVideoLoop = slide.hasAttribute( 'data-background-video-loop' ),
-					backgroundIframe = slide.getAttribute( 'data-background-iframe' );
+					backgroundIframe = slide.getAttribute( 'data-background-iframe' ),
+					backgroundDiv = slide.getAttribute( 'data-background-div' );
 
 				// Images
 				if( backgroundImage ) {
@@ -2901,6 +2902,12 @@
 						iframe.style.maxWidth = '100%';
 
 					background.appendChild( iframe );
+				}
+				// Divs
+				if ( backgroundDiv ) {
+				  var div = document.getElementById(backgroundDiv).cloneNode(true);
+				  background.appendChild(div);
+				  div.style.visibility = "visible";
 				}
 			}
 		}


### PR DESCRIPTION
This simple patch allows backgrounds to be specified as HTML. This has many benefits - you can include diagrams as backgrounds - better still, you can add headings as backgrounds which will appear correctly at the top of the page. To use it, you create a hidden div outside the section and reference it with a data-background-div tag via its ID:

    <section data-background-div="my-heading">
       <p>My content</p>
    </section>
    <div id="my-heading" style="visibility: hidden">
       <h1>My heading</h1>
    </div>

When the background is generated, the div is cloned and added to the background div that Reveal already creates. "if" is used rather than "else if" as this allows this feature to be used alongside data-background-image, which can create some nice effects.
