### PR TITLE
Add the grunt-cli as a dependency instead of assuming global grunt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "node": "~4.1.1"
   },
   "dependencies": {
-    "underscore": "~1.8.3",
     "express": "~4.13.3",
+    "grunt-cli": "^0.1.13",
     "mustache": "~2.1.3",
-    "socket.io": "~1.3.7"
+    "socket.io": "~1.3.7",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "grunt-contrib-qunit": "~0.7.0",


### PR DESCRIPTION
Otherwise, `npm run start` doesn't work without first globally installing grunt.