### PR TITLE
added retire.js to build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,7 +134,14 @@ module.exports = function(grunt) {
 			markdown: {
 				files: [ './*.md' ]
 			}
-		}
+		},
+
+		retire: {
+            js: ['js/reveal.js', 'lib/js/*.js', 'plugin/**/*.js'],
+            node: ['.'],
+            options: {
+            }
+        }
 
 	});
 
@@ -148,6 +155,7 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks( 'grunt-contrib-connect' );
 	grunt.loadNpmTasks( 'grunt-autoprefixer' );
 	grunt.loadNpmTasks( 'grunt-zip' );
+	grunt.loadNpmTasks('grunt-retire');
 
 	// Default task
 	grunt.registerTask( 'default', [ 'css', 'js' ] );

--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "grunt-sass": "~1.1.0-beta",
     "grunt-contrib-connect": "~0.11.2",
     "grunt-autoprefixer": "~3.0.3",
+    "grunt-retire": "~0.3.10",
     "grunt-zip": "~0.17.1",
     "grunt": "~0.4.5",
     "node-sass": "~3.3.3"
   },
-  
+
   "license": "MIT"
 }


### PR DESCRIPTION
-allows security vulnerability check in used npm-dependencies and own scripts
-execute with ```grunt retire```