### PR TITLE
Fix IE 11 crash when changing slides

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2216,7 +2216,7 @@
 		}
 
 		// Announce the current slide contents, for screen readers
-		dom.statusDiv.textContent = currentSlide.textContent;
+		dom.statusDiv.textContent = currentSlide.textContent.trim();
 
 		updateControls();
 		updateProgress();
@@ -3596,7 +3596,7 @@
 						element.classList.remove( 'current-fragment' );
 
 						// Announce the fragments one by one to the Screen Reader
-						dom.statusDiv.textContent = element.textContent;
+						dom.statusDiv.textContent = element.textContent.trim();
 
 						if( i === index ) {
 							element.classList.add( 'current-fragment' );


### PR DESCRIPTION
Assignment of whitespace to textContent triggers it, so always do trim()

IE bug report: https://connect.microsoft.com/IE/feedback/details/1483791/ie-crashes-when-viewing-any-page-on-tpnn-com
