### PR TITLE
Introduce random config

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -147,7 +147,10 @@
 			viewDistance: 3,
 
 			// Script dependencies to load
-			dependencies: []
+			dependencies: [],
+
+			// Randomize slides
+			random: false
 
 		},
 
@@ -3736,32 +3739,39 @@
 
 	function navigateLeft() {
 
-		// Reverse for RTL
-		if( config.rtl ) {
-			if( ( isOverview() || nextFragment() === false ) && availableRoutes().left ) {
-				slide( indexh + 1 );
+		if( config.random ) {
+			navigateRandom(config.random.rangeStart, config.random.rangeEnd);
+		}
+		else {
+			// Reverse for RTL
+			if( config.rtl ) {
+				if( ( isOverview() || nextFragment() === false ) && availableRoutes().left ) {
+					slide( indexh + 1 );
+				}
 			}
-		}
-		// Normal navigation
-		else if( ( isOverview() || previousFragment() === false ) && availableRoutes().left ) {
-			slide( indexh - 1 );
-		}
-
-	}
-
-	function navigateRight() {
-
-		// Reverse for RTL
-		if( config.rtl ) {
-			if( ( isOverview() || previousFragment() === false ) && availableRoutes().right ) {
+			// Normal navigation
+			else if( ( isOverview() || previousFragment() === false ) && availableRoutes().left ) {
 				slide( indexh - 1 );
 			}
 		}
-		// Normal navigation
-		else if( ( isOverview() || nextFragment() === false ) && availableRoutes().right ) {
-			slide( indexh + 1 );
-		}
+	}
 
+	function navigateRight() {
+		if( config.random ) {
+			navigateRandom(config.random.rangeStart, config.random.rangeEnd);
+		}
+		else {
+			// Reverse for RTL
+			if( config.rtl ) {
+				if( ( isOverview() || previousFragment() === false ) && availableRoutes().right ) {
+					slide( indexh - 1 );
+				}
+			}
+			// Normal navigation
+			else if( ( isOverview() || nextFragment() === false ) && availableRoutes().right ) {
+				slide( indexh + 1 );
+			}
+		}
 	}
 
 	function navigateUp() {
@@ -3782,6 +3792,38 @@
 
 	}
 
+	function navigateRandom(randomRangeStart, randomRangeEnd) {
+		var rangeStart = randomRangeStart || 0;
+		var rangeEnd = randomRangeEnd || (toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR )).length - 1);
+		
+		if( rangeEnd < rangeStart ) {
+			//swap the two values
+			rangeEnd = [rangeStart, rangeStart = rangeEnd][0];
+		}
+
+		var randomIndexH;
+		if ( rangeEnd - rangeStart <= 1 ) {
+			//no need to randomize if the range consists of one or two slides
+			randomIndexH = (rangeEnd === indexh) ? rangeStart : rangeEnd;
+		}
+		else {
+			do {
+				randomIndexH = Math.floor(Math.random() * rangeEnd) + rangeStart;
+			} while (randomIndexH === indexh); // keep randomizing if/until we don't come up with the same slide we're already on
+		}
+
+		// Reverse for RTL
+		if( config.rtl ) {
+			if( ( isOverview() || previousFragment() === false ) && availableRoutes().right ) {
+				slide( randomIndexH );
+			}
+		}
+		// Normal navigation
+		else if( ( isOverview() || nextFragment() === false ) && availableRoutes().right ) {
+			slide( randomIndexH );
+		}
+	}
+
 	/**
 	 * Navigates backwards, prioritized in the following order:
 	 * 1) Previous fragment
@@ -3796,20 +3838,26 @@
 				navigateUp();
 			}
 			else {
-				// Fetch the previous horizontal slide, if there is one
-				var previousSlide;
 
-				if( config.rtl ) {
-					previousSlide = toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR + '.future' ) ).pop();
+				if( config.random ) {
+					navigateRandom(config.random.rangeStart, config.random.rangeEnd);
 				}
 				else {
-					previousSlide = toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR + '.past' ) ).pop();
-				}
+					// Fetch the previous horizontal slide, if there is one
+					var previousSlide;
 
-				if( previousSlide ) {
-					var v = ( previousSlide.querySelectorAll( 'section' ).length - 1 ) || undefined;
-					var h = indexh - 1;
-					slide( h, v );
+					if( config.rtl ) {
+						previousSlide = toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR + '.future' ) ).pop();
+					}
+					else {
+						previousSlide = toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR + '.past' ) ).pop();
+					}
+
+					if( previousSlide ) {
+						var v = ( previousSlide.querySelectorAll( 'section' ).length - 1 ) || undefined;
+						var h = indexh - 1;
+						slide( h, v );
+					}
 				}
 			}
 		}
@@ -3821,8 +3869,13 @@
 	 */
 	function navigateNext() {
 
-		// Prioritize revealing fragments
-		if( nextFragment() === false ) {
+		//if autoslide is on and random is on, take over navigation: this check keep randomization at the top (horizontal) level
+		if( autoSlide && !autoSlidePaused && config.random ) {
+			navigateRandom(config.random.rangeStart, config.random.rangeEnd);
+		}
+		else if( nextFragment() === false ) {
+			// Prioritize revealing fragments
+
 			if( availableRoutes().down ) {
 				navigateDown();
 			}


### PR DESCRIPTION
This is a config-based, built-in alternative to proposals like [this one](http://stackoverflow.com/questions/24809752/randomize-slides-in-reveal-js).  This PR addresses #1089, which is closed but perhaps worth reconsidering.

To enable:

				// Simply turning random on will use the entire range of top-level (horizontal) slides
				// Reveal.configure({ random: true });
				
				// Or you can specify an inclusive range of slide numbers
				Reveal.configure({
					random: {
						rangeStart: 5,
						rangeEnd: 8
					}
				});

				//Autoslide can be used with random
				//Reveal.configure({ autoSlide: 3000 });

Notes:

- Of course, random is off by default
- Can be generally enabled (true) or further specify a range of slides (rangeStart and rangeEnd)
- Slide range is inclusive
- Ranges can be manually overridden by any code calling navigateRandom
- Range will autocorrect if not in the proper order ([5,1] becomes [1,5])
- Random navigation will ensure you are not routed to the slide you're already on
- Can be used with autoslide on or off
- Randomized slides are always at the top (horizontal) level - never "basement" levels
- Fragments are still honored
- Transitions are only executed when navigating in a forward (right) direction