### PR TITLE
Added ability to show controls on background videos.

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2889,6 +2889,7 @@
 					backgroundVideo = slide.getAttribute( 'data-background-video' ),
 					backgroundVideoLoop = slide.hasAttribute( 'data-background-video-loop' ),
 					backgroundVideoMuted = slide.hasAttribute( 'data-background-video-muted' ),
+					backgroundVideoControls = slide.hasAttribute( 'data-background-video-controls' ),
 					backgroundIframe = slide.getAttribute( 'data-background-iframe' );
 
 				// Images
@@ -2905,6 +2906,10 @@
 
 					if( backgroundVideoMuted ) {
 						video.muted = true;
+					}
+
+					if( backgroundVideoControls ) {
+						video.setAttribute( 'controls', '' );
 					}
 
 					// Support comma separated lists of video sources


### PR DESCRIPTION
I like to use background videos with no text as fullscreen video slides. Sometimes however, I want controls for such a video.

This commit add the `data-background-video-controls` data attribute, which if given in something like this:

```html
<section data-background-video="vid/gap_of_disappointment.webm" data-background-color="#000000" data-background-video-controls></section>
```

will show native controls on the video.