### PR TITLE
Added before and after event

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3761,6 +3761,7 @@
 	}
 
 	function navigateLeft() {
+		beforeSlide();
 
 		// Reverse for RTL
 		if( config.rtl ) {
@@ -3773,9 +3774,11 @@
 			slide( indexh - 1 );
 		}
 
+		afterSlide();
 	}
 
 	function navigateRight() {
+		beforeSlide();
 
 		// Reverse for RTL
 		if( config.rtl ) {
@@ -3788,24 +3791,29 @@
 			slide( indexh + 1 );
 		}
 
+		afterSlide();
 	}
 
 	function navigateUp() {
+		beforeSlide();
 
 		// Prioritize hiding fragments
 		if( ( isOverview() || previousFragment() === false ) && availableRoutes().up ) {
 			slide( indexh, indexv - 1 );
 		}
 
+		afterSlide();
 	}
 
 	function navigateDown() {
+		beforeSlide();
 
 		// Prioritize revealing fragments
 		if( ( isOverview() || nextFragment() === false ) && availableRoutes().down ) {
 			slide( indexh, indexv + 1 );
 		}
 
+		afterSlide();
 	}
 
 	/**
@@ -3815,7 +3823,8 @@
 	 * 3) Previous horizontal slide
 	 */
 	function navigatePrev() {
-
+		beforeSlide();
+		
 		// Prioritize revealing fragments
 		if( previousFragment() === false ) {
 			if( availableRoutes().up ) {
@@ -3839,14 +3848,16 @@
 				}
 			}
 		}
-
+		
+		afterSlide();
 	}
 
 	/**
 	 * The reverse of #navigatePrev().
 	 */
 	function navigateNext() {
-
+		beforeSlide();
+		
 		// Prioritize revealing fragments
 		if( nextFragment() === false ) {
 			if( availableRoutes().down ) {
@@ -3860,6 +3871,31 @@
 			}
 		}
 
+		afterSlide();
+	}
+
+	/**
+	 * Event before slide.
+	 */
+	function beforeSlide() {
+		dispatchEvent( 'beforeslide', {
+			'indexh': indexh,
+			'indexv': indexv,
+			'previousSlide': previousSlide,
+			'currentSlide': currentSlide
+		} );
+	}
+
+	/**
+	 * Event after slide.
+	 */
+	function afterSlide() {
+		dispatchEvent( 'afterslide', {
+			'indexh': indexh,
+			'indexv': indexv,
+			'previousSlide': previousSlide,
+			'currentSlide': currentSlide
+		} );
 	}
 
 	/**


### PR DESCRIPTION
To handle the content before and after sliding, I've added two events which can be used with the following code.

Reveal.addEventListener( 'beforeslide', function( event ) {
  console.log(event);
});

Reveal.addEventListener( 'afterslide', function( event ) {
  console.log(event);
});