### PR TITLE
Added a description of the undocumented timer-reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,8 @@ If you want to add a theme of your own see the instructions here: [/css/theme/RE
 
 reveal.js comes with a speaker notes plugin which can be used to present per-slide notes in a separate browser window. The notes window also gives you a preview of the next upcoming slide so it may be helpful even if you haven't written any notes. Press the 's' key on your keyboard to open the notes window.
 
+A speaker timer starts as soon as the speaker view is opened. You can reset it to 00:00:00 at any time by simply clicking/tapping on it.
+
 Notes are defined by appending an ```<aside>``` element to a slide as seen below. You can add the ```data-markdown``` attribute to the aside element if you prefer writing notes using Markdown.
 
 Alternatively you can add your notes in a `data-notes` attribute on the slide. Like `<section data-notes="Something important"></section>`.

--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -38,8 +38,8 @@
 
 			#current-slide {
 				position: absolute;
-				width: 65%;
-				height: 100%;
+				width: 50%;
+				height: 50%;
 				top: 0;
 				left: 0;
 				padding-right: 0;
@@ -47,20 +47,19 @@
 
 			#upcoming-slide {
 				position: absolute;
-				width: 35%;
-				height: 40%;
+				width: 50%;
+				height: 50%;
 				right: 0;
 				top: 0;
 			}
 
 			#speaker-controls {
 				position: absolute;
-				top: 40%;
-				right: 0;
-				width: 35%;
-				height: 60%;
+				top: 50%;
+				left: 0;
+				width: 100%;
+				height: 50%;
 				overflow: auto;
-
 				font-size: 18px;
 			}
 


### PR DESCRIPTION
Hi, since the "click to reset" link only appear "on mouse over" in the speaker view, I only found it by accident after I tried to implement it myself. I somehow never used the mouse when presenting and it never occurred to me to click on it. I think a hint in the README.MD file would not be bad ;)

Thanks for the great tool!