### PR TITLE
Topic README node v

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,7 +1003,8 @@ The core of reveal.js is very easy to install. You'll simply need to download a 
 
 Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code. 
 
-1. Install [Node.js](http://nodejs.org/) Please note that RevealJS supports only the current version of Node; i.e., node 0.10 is no longer supported.
+1. Install [Node.js](http://nodejs.org/) 
+	Please note that reveal.js supports only the current version of Node; i.e., node 0.10 is no longer supported.
 
 2. Install [Grunt](http://gruntjs.com/getting-started#installing-the-cli)
 

--- a/README.md
+++ b/README.md
@@ -1003,8 +1003,9 @@ The core of reveal.js is very easy to install. You'll simply need to download a 
 
 Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code. 
 
-1. Install [Node.js](http://nodejs.org/) 
-	Please note that reveal.js supports only the current version of Node; i.e., node 0.10 is no longer supported.
+1. Install [Node.js](http://nodejs.org/)
+
+   Please note that reveal.js supports only the current version of Node; i.e., node 0.10 is no longer supported.
 
 2. Install [Grunt](http://gruntjs.com/getting-started#installing-the-cli)
 

--- a/README.md
+++ b/README.md
@@ -1001,9 +1001,9 @@ The core of reveal.js is very easy to install. You'll simply need to download a 
 
 ### Full setup
 
-Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code.
+Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code. 
 
-1. Install [Node.js](http://nodejs.org/)
+1. Install [Node.js](http://nodejs.org/) Please note that RevealJS supports only the current version of Node; i.e., node 0.10 is no longer supported.
 
 2. Install [Grunt](http://gruntjs.com/getting-started#installing-the-cli)
 


### PR DESCRIPTION
I added the following note to the README.md on line 1008 (in the installation section, under full setup step 1 Install Node.js): Please note that reveal.js supports only the current version of Node; i.e., node 0.10 is no longer supported.