### PR TITLE
Updating package dependencies for newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
     "express": "~4.13.3",
     "grunt-cli": "^0.1.13",
     "mustache": "~2.2.1",
-    "socket.io": "~1.3.7",
+    "socket.io": "~1.4.5",
     "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "grunt-contrib-qunit": "~0.7.0",
+    "grunt-contrib-qunit": "~1.1.0",
     "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-cssmin": "~0.14.0",
     "grunt-contrib-uglify": "~0.9.2",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-watch": "~1.0.0",
     "grunt-sass": "~1.1.0-beta",
     "grunt-contrib-connect": "~0.11.2",
     "grunt-autoprefixer": "~3.0.3",


### PR DESCRIPTION
Issues with current packages:
* socket.io version is 6 months old and that version has insecure dependencies
* grunt-contrib-watch is 24 months old with insecure dependencies
* grunt-contrib-qunit is 12 months old with insecure dependencies