### PR TITLE
README: add encoding to html example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Here's a barebones example of a fully working reveal.js presentation:
 ```html
 <html>
 	<head>
+		<meta charset="utf-8">
 		<link rel="stylesheet" href="css/reveal.css">
 		<link rel="stylesheet" href="css/theme/white.css">
 	</head>


### PR DESCRIPTION
It avoids a huge red warning in FF console when loaded and may
save some hair pulling later.