### PR TITLE
Fixed vulnerable dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# reveal.js [![Build Status](https://travis-ci.org/hakimel/reveal.js.svg?branch=master)](https://travis-ci.org/hakimel/reveal.js)
+# reveal.js [![Build Status](https://travis-ci.org/hakimel/reveal.js.svg?branch=master)](https://travis-ci.org/hakimel/reveal.js) [![Known Vulnerabilities](https://snyk.io/test/github/hakimel/reveal.js/badge.svg)](https://snyk.io/test/github/hakimel/reveal.js)
 
 A framework for easily creating beautiful presentations using HTML. [Check out the live demo](http://lab.hakim.se/reveal-js/).
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "subdomain": "revealjs",
   "main": "js/reveal.js",
   "scripts": {
-    "test": "grunt test",
+    "test": "snyk test && grunt test",
     "start": "grunt serve"
   },
   "author": {
@@ -25,7 +25,7 @@
     "express": "~4.13.3",
     "grunt-cli": "~0.1.13",
     "mustache": "~2.2.1",
-    "socket.io": "~1.3.7"
+    "socket.io": "^1.4.1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
@@ -38,6 +38,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-sass": "~1.1.0-beta",
     "grunt-zip": "~0.17.1",
+    "snyk": "^1.13.2",
     "node-sass": "~3.3.3"
   },
   "license": "MIT"


### PR DESCRIPTION
Reveal.js currently has 2 vulnerabilities introduced via a vulnerable socket.io dependency. 
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/hakimel/reveal.js/d6406e433e94a6755bf8ef5214c71503aa1668e9

This PR upgrades the vulnerable socket.io to the minimal version that isn't vulnerable. 
It's a minor upgrade, so should have no disruption.

I also added `snyk test` to the test process, to help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard), that will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
