### PR TITLE
Add Dockerfile to run reveal.js in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:argon
+
+RUN mkdir -p /usr/src/app
+
+COPY package.json /usr/src/app
+COPY Gruntfile.js /usr/src/app
+COPY *.html /usr/src/app
+COPY plugin /usr/src/app/plugin
+COPY css /usr/src/app/css
+COPY js /usr/src/app/js
+COPY lib /usr/src/app/lib
+
+WORKDIR /usr/src/app
+
+RUN npm install
+RUN npm install -g grunt-cli
+
+EXPOSE 8000 1948

--- a/README.md
+++ b/README.md
@@ -1085,6 +1085,28 @@ Some reveal.js features, like external Markdown and speaker notes, require that 
 - **lib/** All other third party assets (JavaScript, CSS, fonts)
 
 
+### Setup with docker
+
+1. Install [Docker](https://www.docker.com/)
+
+2. Clone the reveal.js repository
+   ```sh
+   $ git clone https://github.com/hakimel/reveal.js.git
+   ```
+
+3. Navigate to the reveal.js folder
+   ```sh
+   $ cd reveal.js
+   ```
+
+4. Build docker image
+   ```sh
+   $ docker build -t reveal-js .
+   ```
+
+5. Start with grunt to serve files by using `$ docker run -p 8080:8080 --name reveal-js -d reveal-js grunt serve`.
+   Start Socket.io server for multiplex configuration by using `$ docker run -p 1948:1948 --name reveal-js -d reveal-js node plugin/multiplex`.
+
 ## License
 
 MIT licensed


### PR DESCRIPTION
I added a Dockerfile with setup, so you can easily run reveal.js within
a docker container. This also makes it easier to start reveal.js on a
remote server.
