### PR TITLE
Add selection colour for Mozilla Firefox

### DIFF
--- a/css/theme/beige.css
+++ b/css/theme/beige.css
@@ -29,6 +29,11 @@ body {
   background: rgba(79, 64, 28, 0.99);
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: rgba(79, 64, 28, 0.99);
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/black.css
+++ b/css/theme/black.css
@@ -25,6 +25,11 @@ body {
   background: #bee4fd;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #bee4fd;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/blood.css
+++ b/css/theme/blood.css
@@ -28,6 +28,11 @@ body {
   background: #a23;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #a23;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/league.css
+++ b/css/theme/league.css
@@ -31,6 +31,11 @@ body {
   background: #FF5E99;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #FF5E99;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/moon.css
+++ b/css/theme/moon.css
@@ -29,6 +29,11 @@ body {
   background: #d33682;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #d33682;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/night.css
+++ b/css/theme/night.css
@@ -23,6 +23,11 @@ body {
   background: #e7ad52;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #e7ad52;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/serif.css
+++ b/css/theme/serif.css
@@ -25,6 +25,11 @@ body {
   background: #26351C;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #26351C;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/simple.css
+++ b/css/theme/simple.css
@@ -25,6 +25,11 @@ body {
   background: rgba(0, 0, 0, 0.99);
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: rgba(0, 0, 0, 0.99);
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/sky.css
+++ b/css/theme/sky.css
@@ -32,6 +32,11 @@ body {
   background: #134674;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #134674;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/solarized.css
+++ b/css/theme/solarized.css
@@ -29,6 +29,11 @@ body {
   background: #d33682;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #d33682;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;

--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -25,6 +25,11 @@ body {
   background: #98bdef;
   text-shadow: none; }
 
+::-moz-selection {
+  color: #fff;
+  background: #98bdef;
+  text-shadow: none; }
+
 .reveal .slides > section,
 .reveal .slides > section > section {
   line-height: 1.3;


### PR DESCRIPTION
On Mozilla Firefox, the default selection/highlight colour is used when selecting slide content (text, images, etc). This change makes it so that the colour defined for other browsers in each theme will be used on Firefox as well. No more clashing colours! :)