### PR TITLE
add refused-to-display tips in link-preview-overlay

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -1229,6 +1229,16 @@ html:-moz-full-screen-ancestor {
 		visibility: visible;
 	}
 
+	.reveal .overlay.overlay-preview.loaded .viewport-inner  {
+		position: absolute;
+		z-index: -1;
+		left: 0;
+		top: 60px;
+		width: 100%;
+		text-align: center;
+		letter-spacing: normal;
+	}
+
 	.reveal .overlay.overlay-preview.loaded .spinner {
 		opacity: 0;
 		visibility: hidden;

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1500,6 +1500,9 @@
 			'<div class="spinner"></div>',
 			'<div class="viewport">',
 				'<iframe src="'+ url +'"></iframe>',
+				'<small class="viewport-inner">',
+				'This link is refused to display in a frame due to its policy',
+				'</small>',
 			'</div>'
 		].join('');
 


### PR DESCRIPTION
PreviewLinks is a super convenient feature while many of websites are refused to display their webpages in a frame due to their policy. Some set Content Security Policy "frame-ancestors 'none'" and others set 'X-Frame-Options'.

These kind of errors don't trigger `iframe.onerror` which is a big mis-implementation of browsers in my views. So we have to work around it with some tricks and my proposal is to place a `z-index: -1` element under the iframe, which would be only saw if the iframe display nothing (and it mostly due to sort of 'refused-to-display' policy)
