### PR TITLE
Removing duplicated "position" property at pdf.css

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -86,7 +86,6 @@ ul, ol, div, p {
 	page-break-after: always !important;
 
 	visibility: visible !important;
-	position: relative !important;
 	display: block !important;
 	position: relative !important;
 


### PR DESCRIPTION
Found that by running css-lint on the code