### PR TITLE
Slide-specific vertical centering override

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -478,6 +478,10 @@ html:-moz-full-screen-ancestor {
 	opacity: 0;
 }
 
+/* Slide-specific vertical centering override */
+.reveal .slides section[data-vertical-align-top]{
+	top: 0 !important;
+}
 
 /*********************************************
  * Mixins for readability of transitions


### PR DESCRIPTION
When a specific section has to be shown not vertically aligned to the center.
`    <section data-vertical-align-top>
`