### PR TITLE
For a fragment: allow to show a separate note defined in it

### DIFF
--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -50,7 +50,7 @@ var RevealNotes = (function() {
 		/**
 		 * Posts the current slide data to the notes window
 		 */
-		function post() {
+		function post(event) {
 
 			var slideElement = Reveal.getCurrentSlide(),
 				notesElement = slideElement.querySelector( 'aside.notes' );
@@ -63,6 +63,15 @@ var RevealNotes = (function() {
 				whitespace: 'normal',
 				state: Reveal.getState()
 			};
+
+			// Look for notes defined in a fragment, if it is a fragmentshown event
+			if (event && event.hasOwnProperty('fragment')) {
+				var innerNotes = event.fragment.querySelector( 'aside.notes' );
+
+				if ( innerNotes) {
+					notesElement = innerNotes;
+				}
+			}
 
 			// Look for notes defined in a slide attribute
 			if( slideElement.hasAttribute( 'data-notes' ) ) {


### PR DESCRIPTION
When a slide has several fragments it could be convenient to define a note for each of them. In this case we need to show only this specific note defined in a fragment and not others. General note of a slide shouldn't be also shown, as a more specific one should have greater relevance in this case.
