### PR TITLE
Workaround rendering glitch in Firefox 47+

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -394,6 +394,7 @@ body {
 	text-align: center;
 	perspective: 600px;
 	perspective-origin: 50% 40%;
+	transform-style: preserve-3d;
 }
 
 .reveal .slides>section {
@@ -408,7 +409,7 @@ body {
 	padding: 20px 0px;
 
 	z-index: 10;
-	transform-style: preserve-3d;
+	transform-style: flat;
 	transition: transform-origin 800ms cubic-bezier(0.260, 0.860, 0.440, 0.985),
 				transform 800ms cubic-bezier(0.260, 0.860, 0.440, 0.985),
 				visibility 800ms cubic-bezier(0.260, 0.860, 0.440, 0.985),
@@ -842,6 +843,7 @@ body {
 	top: 0;
 	left: 0;
 	perspective: 600px;
+	transform-style: preserve-3d;
 }
 	.reveal .slide-background {
 		display: none;
@@ -1011,6 +1013,7 @@ body {
 .reveal.overview {
 	perspective-origin: 50% 50%;
 	perspective: 700px;
+	transform-style: preserve-3d;
 
 	.slides section {
 		height: 100%;


### PR DESCRIPTION
Including slides, overview been cutoff and text became blurry

<img width="1231" alt="2016-07-30 6 41 45" src="https://cloud.githubusercontent.com/assets/2639151/17270331/b2127b26-5692-11e6-87b3-16cf2ac4d830.png">
<img width="1231" alt="2016-07-30 6 41 45" src="https://camo.githubusercontent.com/a6b5ee54fe864bb1f6afd9421acb4aae7825c1a8/687474703a2f2f692e696d6775722e636f6d2f766848327661722e6a7067">
