### PR TITLE
Fixed double navigations on Apple devices

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1055,9 +1055,9 @@
 		// supports both
 		var pointerEvents = [ 'touchstart', 'click' ];
 
-		// Only support touch for Android, fixes double navigations in
+		// Only support touch for Android and Apple devices fixes double navigations in
 		// stock browser
-		if( UA.match( /android/gi ) ) {
+		if( isMobileDevice ) {
 			pointerEvents = [ 'touchstart' ];
 		}
 


### PR DESCRIPTION
I have a problem on iPhone, iPad. When you touch on navigations buttons, going doubleclick.