### PR TITLE
Hide invisible status text

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -558,7 +558,7 @@
 		var text = "";
 		if(node.nodeType === 3) { //text node
 			text += node.textContent;
-		}else {
+		}else if (node.nodeType === 1) { //element node
 			var isAriaHidden = node.getAttribute('aria-hidden');
 			var isDisplayHidden = window.getComputedStyle(node)['display'] === 'none';
 			if (isAriaHidden !== 'true' && !isDisplayHidden) {

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -554,6 +554,23 @@
 
 	}
 
+	function getStatusText(node) {
+		var text = "";
+		if(node.nodeType === 3) { //text node
+			text += node.textContent;
+		}else {
+			var isAriaHidden = node.getAttribute('aria-hidden');
+			var isDisplayHidden = window.getComputedStyle(node)['display'] === 'none';
+			if (isAriaHidden !== 'true' && !isDisplayHidden) {
+				var children = node.childNodes;
+				for (var i = 0;i < children.length; i++) {
+					text += getStatusText(children[i]);
+				}
+			}
+		}
+		return text;
+	}
+
 	/**
 	 * Configures the presentation for printing to a static
 	 * PDF.
@@ -2217,7 +2234,7 @@
 		}
 
 		// Announce the current slide contents, for screen readers
-		dom.statusDiv.textContent = currentSlide.textContent;
+		dom.statusDiv.textContent = getStatusText(currentSlide);
 
 		updateControls();
 		updateProgress();
@@ -3618,7 +3635,7 @@
 						element.classList.remove( 'current-fragment' );
 
 						// Announce the fragments one by one to the Screen Reader
-						dom.statusDiv.textContent = element.textContent;
+						dom.statusDiv.textContent = getStatusText(element);
 
 						if( i === index ) {
 							element.classList.add( 'current-fragment' );


### PR DESCRIPTION
this pull request will no longer add aria-hidden="true" and display: none elements to the status div text.

Solves https://github.com/hakimel/reveal.js/issues/1656