### PR TITLE
Fixed slide function in the case no slides exist (Issue #1678)

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
 			<div class="slides">
 				<section>Slide 1</section>
 				<section>Slide 2</section>
+				<section>
+					 <section>Vertical Slide 1</section>
+					 <section>Vertical Slide 2</section>
+			 </section>
 			</div>
 		</div>
 
@@ -36,6 +40,10 @@
 			// More info https://github.com/hakimel/reveal.js#configuration
 			Reveal.initialize({
 				history: true,
+				// Transition
+				transition: 'concave', // none/fade/slide/convex/concave/zoom
+				// Transition style for full page slide backgrounds
+		    backgroundTransition: 'concave', // none/fade/slide/convex/concave/zoom
 
 				// More info https://github.com/hakimel/reveal.js#dependencies
 				dependencies: [

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2175,7 +2175,7 @@
 		// Find the current horizontal slide and any possible vertical slides
 		// within it
 		var currentHorizontalSlide = horizontalSlides[ indexh ],
-			currentVerticalSlides = currentHorizontalSlide.querySelectorAll( 'section' );
+			currentVerticalSlides = currentHorizontalSlide ? currentHorizontalSlide.querySelectorAll( 'section' ) : [];
 
 		// Store references to the previous and current slides
 		currentSlide = currentVerticalSlides[ indexv ] || currentHorizontalSlide;
@@ -2231,7 +2231,7 @@
 		}
 
 		// Announce the current slide contents, for screen readers
-		dom.statusDiv.textContent = currentSlide.textContent;
+		if(currentSlide) dom.statusDiv.textContent = currentSlide.textContent;
 
 		updateControls();
 		updateProgress();


### PR DESCRIPTION
In the process of inviting Reveal.initialize()

In the case slides are empty `Reveal.initialize` breaks on slide() function, initialize() -> readURL() -> slide() tries to set to the first slide (which doesn't exist)

This fixes slide() function by checking if slide exist before accessing it
Closes #1678