### PR TITLE
autoSlide duration with playbackRate

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3767,12 +3767,13 @@
 			// If there are media elements with data-autoplay,
 			// automatically set the autoSlide duration to the
 			// length of that media. Not applicable if the slide
-			// is divided up into fragments.
+			// is divided up into fragments. 
+			// playbackRate is accounted for in the duration.
 			if( currentSlide.querySelectorAll( '.fragment' ).length === 0 ) {
 				toArray( currentSlide.querySelectorAll( 'video, audio' ) ).forEach( function( el ) {
 					if( el.hasAttribute( 'data-autoplay' ) ) {
-						if( autoSlide && el.duration * 1000 > autoSlide ) {
-							autoSlide = ( el.duration * 1000 ) + 1000;
+						if( autoSlide && (el.duration * 1000 / el.playbackRate ) > autoSlide ) {
+							autoSlide = ( el.duration * 1000 / el.playbackRate ) + 1000;
 						}
 					}
 				} );


### PR DESCRIPTION
The autoSlide duration of media elements with data-autoplay now takes the playbackRate of said media element into account when setting the duration so that autoSlide and the media element stay in sync.