### PR TITLE
Logitech R400 on Ubuntu blackout button support

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3968,8 +3968,8 @@
 		// keyboard modifier key is present
 		if( activeElementIsCE || activeElementIsInput || (event.shiftKey && event.keyCode !== 32) || event.altKey || event.ctrlKey || event.metaKey ) return;
 
-		// While paused only allow resume keyboard events; 'b', '.''
-		var resumeKeyCodes = [66,190,191];
+		// While paused only allow resume keyboard events; 'b', 'v', '.'
+		var resumeKeyCodes = [66,86,190,191];
 		var key;
 
 		// Custom key bindings for togglePause should be able to resume
@@ -4041,8 +4041,8 @@
 				case 32: isOverview() ? deactivateOverview() : event.shiftKey ? navigatePrev() : navigateNext(); break;
 				// return
 				case 13: isOverview() ? deactivateOverview() : triggered = false; break;
-				// two-spot, semicolon, b, period, Logitech presenter tools "black screen" button
-				case 58: case 59: case 66: case 190: case 191: togglePause(); break;
+				// two-spot, semicolon, b, v, period, Logitech presenter tools "black screen" button
+				case 58: case 59: case 66: case 86: case 190: case 191: togglePause(); break;
 				// f
 				case 70: enterFullscreen(); break;
 				// a


### PR DESCRIPTION
On Ubuntu 16.04, the Logitech R400's blackout button gets mapped to 'v' (keyCode 86). I don't know why this is, but since nothing else is currently using 'v', this allows it to be supported out of the box.