### PR TITLE
Sass extension

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
 					{
 						expand: true,
 						cwd: 'css/theme/source',
-						src: ['*.scss'],
+						src: ['*.sass', '*.scss'],
 						dest: 'css/theme',
 						ext: '.css'
 					}
@@ -118,7 +118,12 @@ module.exports = function(grunt) {
 				tasks: 'js'
 			},
 			theme: {
-				files: [ 'css/theme/source/*.scss', 'css/theme/template/*.scss' ],
+				files: [
+					'css/theme/source/*.sass',
+					'css/theme/source/*.scss',
+					'css/theme/template/*.sass',
+					'css/theme/template/*.scss'
+				],
 				tasks: 'css-themes'
 			},
 			css: {

--- a/README.md
+++ b/README.md
@@ -301,6 +301,20 @@ Reveal.initialize({
 });
 ```
 
+If you wish to disable this behavior and do your own scaling (e.g. using media queries), try these settings:
+
+```javascript
+Reveal.initialize({
+
+	...
+
+	width: "100%",
+	height: "100%",
+	margin: 0,
+	minScale: 1,
+	maxScale: 1
+});
+```
 
 ### Dependencies
 


### PR DESCRIPTION
Support `*.sass` files for custom themes in addition to `*.scss`.
