### PR TITLE
Fix: Background image was not displayed on very first title slide

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2971,13 +2971,6 @@
 		// Hide the slide element
 		slide.style.display = 'none';
 
-		// Hide the corresponding background element
-		var indices = getIndices( slide );
-		var background = getSlideBackground( indices.h, indices.v );
-		if( background ) {
-			background.style.display = 'none';
-		}
-
 	}
 
 	/**


### PR DESCRIPTION
Hi, 

great job with reveal.js! I stumbled over some minor quirks though. For one, I hope to provide a fix:

I didn't see a background image on the very first slide containing the title and author information:

```
<body>
<body>
  <div class="reveal">
    <div class="slides">

        <section data-background-image="_res/kb.jpg">
            <h1 class="title">Lernen lernen</h1>
            <h2 class="author">Jan Beilicke</h2>
            <h3 class="date">28.10.2016</h3>
        </section>
        ...
```

After some debugging, it turned out that the background existed but was set to `display: none`. After I removed the corresponding lines in `hideSlide()` it was displayed again. Afterwards, I tested the other slides with background properties set and unset and they behave as expected. I couldn't find out yet, why the background of that particular slide wasn't displayed when `showSlide()` is called. 

Feel free to discuss my pull request or accept it.
Cheers,
//jotbe
