### PR TITLE
Defaults in README are not current

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,13 @@ Reveal.initialize({
 	previewLinks: false,
 
 	// Transition style
-	transition: 'default', // none/fade/slide/convex/concave/zoom
+	transition: 'slide', // none/fade/slide/convex/concave/zoom
 
 	// Transition speed
 	transitionSpeed: 'default', // default/fast/slow
 
 	// Transition style for full page slide backgrounds
-	backgroundTransition: 'default', // none/fade/slide/convex/concave/zoom
+	backgroundTransition: 'fade', // none/fade/slide/convex/concave/zoom
 
 	// Number of slides away from the current that are visible
 	viewDistance: 3,


### PR DESCRIPTION
The `transition` and `backgroundTransition` defaults presented in the README are not up to date with reveal.js