### PR TITLE
use HeadJS for script loading in math plugin

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -10,7 +10,7 @@ var RevealMath = window.RevealMath || (function(){
 	options.mathjax = options.mathjax || 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
 
-	loadScript( options.mathjax + '?config=' + options.config, function() {
+	head.load( options.mathjax + '?config=' + options.config, function() {
 
 		MathJax.Hub.Config({
 			messageStyle: 'none',
@@ -34,34 +34,5 @@ var RevealMath = window.RevealMath || (function(){
 		} );
 
 	} );
-
-	function loadScript( url, callback ) {
-
-		var head = document.querySelector( 'head' );
-		var script = document.createElement( 'script' );
-		script.type = 'text/javascript';
-		script.src = url;
-
-		// Wrapper for callback to make sure it only fires once
-		var finish = function() {
-			if( typeof callback === 'function' ) {
-				callback.call();
-				callback = null;
-			}
-		}
-
-		script.onload = finish;
-
-		// IE
-		script.onreadystatechange = function() {
-			if ( this.readyState === 'loaded' ) {
-				finish();
-			}
-		}
-
-		// Normal browsers
-		head.appendChild( script );
-
-	}
 
 })();


### PR DESCRIPTION
reveal.js depends on HeadJS anyway, so we might as well use that.

Note, however, that I haven't actually tested this, as I'm not currently using this plugin. It's just something I stumbled across while looking at various plugins for reference. I don't see a reason why this wouldn't work though (HeadJS uses the file extension to decide between CSS and JavaScript).