### PR TITLE
Allow add class to slide background

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -777,6 +777,7 @@
 
 		var data = {
 			background: slide.getAttribute( 'data-background' ),
+			backgroundClass: slide.getAttribute( 'data-background-class' ),
 			backgroundSize: slide.getAttribute( 'data-background-size' ),
 			backgroundImage: slide.getAttribute( 'data-background-image' ),
 			backgroundVideo: slide.getAttribute( 'data-background-video' ),
@@ -805,8 +806,9 @@
 		// Create a hash for this combination of background settings.
 		// This is used to determine when two slide backgrounds are
 		// the same.
-		if( data.background || data.backgroundColor || data.backgroundImage || data.backgroundVideo || data.backgroundIframe ) {
+		if( data.background || data.backgroundClass || data.backgroundColor || data.backgroundImage || data.backgroundVideo || data.backgroundIframe ) {
 			element.setAttribute( 'data-background-hash', data.background +
+					     										data.backgroundClass +
 															data.backgroundSize +
 															data.backgroundImage +
 															data.backgroundVideo +
@@ -823,6 +825,7 @@
 		if( data.backgroundRepeat ) element.style.backgroundRepeat = data.backgroundRepeat;
 		if( data.backgroundPosition ) element.style.backgroundPosition = data.backgroundPosition;
 		if( data.backgroundTransition ) element.setAttribute( 'data-background-transition', data.backgroundTransition );
+		if (data.backgroundClass) element.classList.add(data.backgroundClass);
 
 		container.appendChild( element );
 


### PR DESCRIPTION
Allow add class to slide background by `data-background-class`. 
Eg: `data-background-class="blurred"` and in `css` file:
```
.blurred {
    -webkit-filter: blur(5px);
    -moz-filter: blur(5px);
    -o-filter: blur(5px);
    -ms-filter: blur(5px);
    filter: blur(5px);
}
```
Background is blurred 5px and it look like http://oanhnn.github.io/slides/2016-11-21-unit-test-with-laravel.html#/4