### PR TITLE
Implementing a better data-trim

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,20 @@ Reveal.initialize({
 });
 ```
 
+If you wish to disable this behavior and do your own scaling (e.g. using media queries), try these settings:
+
+```javascript
+Reveal.initialize({
+
+	...
+
+	width: "100%",
+	height: "100%",
+	margin: 0,
+	minScale: 1,
+	maxScale: 1
+});
+```
 
 ### Dependencies
 

--- a/plugin/highlight/highlight.js
+++ b/plugin/highlight/highlight.js
@@ -1,5 +1,52 @@
 // START CUSTOM REVEAL.JS INTEGRATION
 (function() {
+	// Function to perform a better "data-trim" on code snippets
+	// Will slice an indentation amount on each line of the snippet (amount based on the line having the lowest indentation length)
+	function betterTrim(snippetEl) {
+		// Helper functions
+		function trimLeft(val) {
+			// Adapted from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill
+			return val.replace(/^[\s\uFEFF\xA0]+/g, '');
+		}
+		function trimLineBreaks(input) {
+			var lines = input.split('\n');
+
+			// Trim line-breaks from the beginning
+			for (var i = 0; i < lines.length; i++) {
+				if (lines[i].trim() === '') {
+					lines.splice(i--, 1);
+				} else break;
+			}
+
+			// Trim line-breaks from the end
+			for (var i = lines.length-1; i >= 0; i--) {
+				if (lines[i].trim() === '') {
+					lines.splice(i, 1);
+				} else break;
+			}
+
+			return lines.join('\n');
+		}
+
+		// Main function for betterTrim()
+		return (function(snippetEl) {
+			var content = trimLineBreaks(snippetEl.innerHTML);
+			var lines = content.split('\n');
+			// Calculate the minimum amount to remove on each line start of the snippet (can be 0)
+			var pad = lines.reduce(function(acc, line) {
+				if (line.length > 0 && trimLeft(line).length > 0 && acc > line.length - trimLeft(line).length) {
+					return line.length - trimLeft(line).length;
+				}
+				return acc;
+			}, Number.POSITIVE_INFINITY);
+			// Slice each line with this amount
+			return lines.map(function(line, index) {
+				return line.slice(pad);
+			})
+			.join('\n');
+		})(snippetEl);
+	}
+
 	if( typeof window.addEventListener === 'function' ) {
 		var hljs_nodes = document.querySelectorAll( 'pre code' );
 
@@ -8,7 +55,7 @@
 
 			// trim whitespace if data-trim attribute is present
 			if( element.hasAttribute( 'data-trim' ) && typeof element.innerHTML.trim === 'function' ) {
-				element.innerHTML = element.innerHTML.trim();
+				element.innerHTML = betterTrim(element);
 			}
 
 			// Now escape html unless prevented by author


### PR DESCRIPTION
Inserting code snippets can sometimes be painful for the developer's indentation of HTML, constrained by the `<pre>` tag to pull code to the left like this :

```html
  <body>
    <div class="reveal">
      <div class="slides">

          <section>
            <section>
              <pre><code class="js" data-trim>
const fs = require('fs');

fs.writeFile('filename.txt', 'Hello World!', (err) => {
  if (err) throw err;

  console.log('Le contenu du fichier a bien été modifié.');
});
              </code></pre>
            </section>
          </section>

      </div>
    </div>
  </body>
```
✖ This breaks the editor's code folding, and makes more difficult the reading of the code when working on large presentations.

Now with the new smart `data-trim` attribute, each code snippet will be processed line-by-line to be automatically reindented to the left :

![image](https://cloud.githubusercontent.com/assets/1759179/20545544/0aa7acca-b110-11e6-9fd8-1dd71d940594.png)

No more pain for the developer to maintain his presentation code indentation, can allow code folding in the editor like you would do in a normal situation :

```html
          <section>
            <section>
              <pre><code class="js" data-trim>
                const fs = require('fs');

                fs.writeFile('filename.txt', 'Hello World!', (err) => {
                  if (err) throw err;

                  console.log('Le contenu du fichier a bien été modifié.');
                });
              </code></pre>
            </section>
          </section>
```
✔