### PR TITLE
Reduce required Node.js version to 4.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,7 +929,7 @@ Reveal.initialize({
 
 Then:
 
-1. Install [Node.js](http://nodejs.org/) (1.0.0 or later)
+1. Install [Node.js](http://nodejs.org/) (4.0.0 or later)
 2. Run ```npm install```
 3. Run ```node plugin/notes-server```
 
@@ -1115,7 +1115,7 @@ The core of reveal.js is very easy to install. You'll simply need to download a 
 
 Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code.
 
-1. Install [Node.js](http://nodejs.org/) (1.0.0 or later)
+1. Install [Node.js](http://nodejs.org/) (4.0.0 or later)
 
 1. Clone the reveal.js repository
    ```sh

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git://github.com/hakimel/reveal.js.git"
   },
   "engines": {
-    "node": "~6.9.1"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "express": "~4.14.0",


### PR DESCRIPTION
The development workflow can be used with Node 4+, not just Node 6. We should avoid showing warnings and errors when users are installing this package via npm/yarn.

Ref. #1729, #1743.
Closes #1725.