### PR TITLE
Shift `dependencies` to `devDependencies`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,11 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "dependencies": {
-    "express": "~4.14.0",
-    "grunt-cli": "~1.2.0",
-    "mustache": "~2.2.1",
-    "socket.io": "^1.4.8"
-  },
   "devDependencies": {
+    "express": "~4.14.0",
     "grunt": "~1.0.1",
     "grunt-autoprefixer": "~3.0.3",
+    "grunt-cli": "~1.2.0",
     "grunt-contrib-connect": "~0.11.2",
     "grunt-contrib-cssmin": "~0.14.0",
     "grunt-contrib-jshint": "~0.11.3",
@@ -39,7 +35,9 @@
     "grunt-sass": "~1.2.0",
     "grunt-retire": "~0.3.10",
     "grunt-zip": "~0.17.1",
-    "node-sass": "~3.13.0"
+    "mustache": "~2.2.1",
+    "node-sass": "~3.13.0",
+    "socket.io": "^1.4.8"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The `reveal.js` npm module is typically installed to access the CSS/JS assets for Reveal.js. For those that want to run the plugins, they would clone the whole repository. Hence, it doesn’t make sense to include those as `dependencies`, which will increase download times.

Closes #1734.

**Note:** this might count as a breaking change.