### PR TITLE
Fix for broken alt-click element zoom, ticket #1758.

### DIFF
--- a/plugin/zoom-js/zoom.js
+++ b/plugin/zoom-js/zoom.js
@@ -5,19 +5,10 @@
 	document.querySelector( '.reveal .slides' ).addEventListener( 'mousedown', function( event ) {
 		var modifier = ( Reveal.getConfig().zoomKey ? Reveal.getConfig().zoomKey : 'alt' ) + 'Key';
 
-		var zoomPadding = 20;
-		var revealScale = Reveal.getScale();
-
 		if( event[ modifier ] && isEnabled ) {
 			event.preventDefault();
-
-			var bounds = event.target.getBoundingClientRect();
-
 			zoom.to({
-				x: ( bounds.left * revealScale ) - zoomPadding,
-				y: ( bounds.top * revealScale ) - zoomPadding,
-				width: ( bounds.width * revealScale ) + ( zoomPadding * 2 ),
-				height: ( bounds.height * revealScale ) + ( zoomPadding * 2 ),
+				element: event.target,
 				pan: false
 			});
 		}


### PR DESCRIPTION
Don't bother to zoom based on coordinates (left, top, width height), rather just zoom on a HTML element.