### PR TITLE
Remove 'history: true' from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,6 @@
 		<script>
 			// More info https://github.com/hakimel/reveal.js#configuration
 			Reveal.initialize({
-				history: true,
-
 				// More info https://github.com/hakimel/reveal.js#dependencies
 				dependencies: [
 					{ src: 'plugin/markdown/marked.js' },


### PR DESCRIPTION
Readme says the default is 'history: false', so it may be surprising
for users - it's easy to miss the contradicting setting in index.html