### PR TITLE
Allow showNotes to be triggered by query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,7 +849,8 @@ Here's an example of an exported presentation that's been uploaded to SlideShare
 
 Export dimensions are inferred from the configured [presentation size](#presentation-size). Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand onto using the `pdfMaxPagesPerSlide` config option, for example `Reveal.configure({ pdfMaxPagesPerSlide: 1 })` ensures that no slide ever grows to more than one printed page.
 
-1. Open your presentation with `print-pdf` included in the query string i.e. http://localhost:8000/?print-pdf#/. This triggers the default index HTML to load the PDF print stylesheet ([css/print/pdf.css](https://github.com/hakimel/reveal.js/blob/master/css/print/pdf.css)). You can test this with [lab.hakim.se/reveal-js?print-pdf](http://lab.hakim.se/reveal-js?print-pdf).
+1.1 Open your presentation with `print-pdf` included in the query string i.e. http://localhost:8000/?print-pdf#/. This triggers the default index HTML to load the PDF print stylesheet ([css/print/pdf.css](https://github.com/hakimel/reveal.js/blob/master/css/print/pdf.css)). You can test this with [lab.hakim.se/reveal-js?print-pdf](http://lab.hakim.se/reveal-js?print-pdf).
+1.2 Optionally, open your presentation with `show-notes` added to the query string i.e. http://localhost:8000/?print-pdf&show-notes#/. This will add the speaker notes to your PDFs. 
 2. Open the in-browser print dialog (CTRL/CMD+P).
 3. Change the **Destination** setting to **Save as PDF**.
 4. Change the **Layout** to **Landscape**.

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1001,6 +1001,10 @@
 		if( config.pause === false ) {
 			resume();
 		}
+		
+		if( isShowingNotes() ) {
+			config.showNotes = true;	
+		}
 
 		if( config.showNotes ) {
 			dom.speakerNotes.classList.add( 'visible' );
@@ -1458,6 +1462,15 @@
 	function isPrintingPDF() {
 
 		return ( /print-pdf/gi ).test( window.location.search );
+
+	}
+
+	/**
+	 * Checks if this instance is being used to show notes.
+	 */
+	function isShowingNotes() {
+
+		return ( /show-notes/gi ).test( window.location.search );
 
 	}
 


### PR DESCRIPTION
My regular use case for showNotes is for PDF print-outs. Restricting the showNotes setup to configuration only requires me to change a file. Allowing to add "show-notes" to the query parameters makes life easier again.