### PR TITLE
added toggleHelp function

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1629,6 +1629,18 @@
 	}
 
 	/**
+	 * Open or close help overlay window.
+	 */
+	function toggleHelp(){
+		if( dom.overlay ) {
+			closeOverlay();
+		}
+		else {
+			showHelp( true );
+		}
+	}
+	
+	/**
 	 * Opens an overlay window with help material.
 	 */
 	function showHelp() {
@@ -4113,12 +4125,7 @@
 
 		// Check if the pressed key is question mark
 		if( event.shiftKey && event.charCode === 63 ) {
-			if( dom.overlay ) {
-				closeOverlay();
-			}
-			else {
-				showHelp( true );
-			}
+			toggleHelp();
 		}
 
 	}
@@ -4818,6 +4825,7 @@
 
 		// Shows a help overlay with keyboard shortcuts
 		showHelp: showHelp,
+		toggleHelp: toggleHelp,
 
 		// Forces an update in slide layout
 		layout: layout,

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1630,15 +1630,26 @@
 
 	/**
 	 * Open or close help overlay window.
+	 *
+	 * @param {Boolean} [override] Flag which overrides the
+	 * toggle logic and forcibly sets the desired state. True means
+	 * help is open, false means it's closed.
 	 */
-	function toggleHelp(){
-		if( dom.overlay ) {
-			closeOverlay();
+	function toggleHelp( override ){
+		
+		if( typeof override === 'boolean' ) {
+			override ? showHelp( true ) : closeOverlay();
 		}
-		else {
-			showHelp( true );
+		else {		
+			if( dom.overlay ) {
+				closeOverlay();
+			}
+			else {
+				showHelp( true );
+			}
 		}
 	}
+
 	
 	/**
 	 * Opens an overlay window with help material.


### PR DESCRIPTION
this way a key can be given ability to toggleHelp on and off.  Previously Reveal.showHelp could open the help screen, but no way to close it.