### PR TITLE
Update to README.md for PDF printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,7 +849,7 @@ Here's an example of an exported presentation that's been uploaded to SlideShare
 
 In order to enable PDF print capability in your presentation, the following code must be inserted in the HEAD section of your HTML document.
 
-'''html
+```html
 <!-- Printing and PDF exports -->
 <script>
 	var link = document.createElement( 'link' );
@@ -858,7 +858,7 @@ In order to enable PDF print capability in your presentation, the following code
 	link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
 	document.getElementsByTagName( 'head' )[0].appendChild( link );
 </script>
-'''
+```
 
 Export dimensions are inferred from the configured [presentation size](#presentation-size). Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand onto using the `pdfMaxPagesPerSlide` config option, for example `Reveal.configure({ pdfMaxPagesPerSlide: 1 })` ensures that no slide ever grows to more than one printed page.
 

--- a/README.md
+++ b/README.md
@@ -847,6 +847,19 @@ Reveal.initialize({
 Presentations can be exported to PDF via a special print stylesheet. This feature requires that you use [Google Chrome](http://google.com/chrome) or [Chromium](https://www.chromium.org/Home) and to be serving the presention from a webserver.
 Here's an example of an exported presentation that's been uploaded to SlideShare: http://www.slideshare.net/hakimel/revealjs-300.
 
+In order to enable PDF print capability in your presentation, the following code must be inserted in the HEAD section of your HTML document.
+
+'''html
+<!-- Printing and PDF exports -->
+<script>
+	var link = document.createElement( 'link' );
+	link.rel = 'stylesheet';
+	link.type = 'text/css';
+	link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+	document.getElementsByTagName( 'head' )[0].appendChild( link );
+</script>
+'''
+
 Export dimensions are inferred from the configured [presentation size](#presentation-size). Slides that are too tall to fit within a single page will expand onto multiple pages. You can limit how many pages a slide may expand onto using the `pdfMaxPagesPerSlide` config option, for example `Reveal.configure({ pdfMaxPagesPerSlide: 1 })` ensures that no slide ever grows to more than one printed page.
 
 1. Open your presentation with `print-pdf` included in the query string i.e. http://localhost:8000/?print-pdf#/. This triggers the default index HTML to load the PDF print stylesheet ([css/print/pdf.css](https://github.com/hakimel/reveal.js/blob/master/css/print/pdf.css)). You can test this with [lab.hakim.se/reveal-js?print-pdf](http://lab.hakim.se/reveal-js?print-pdf).


### PR DESCRIPTION
I found that when trying to print to PDF, there was a block of code missing from the HTML, this block is necessary for the PDF layout to be rendered properly and I didn't see it anywhere in the README so I added it in.