### PR TITLE
Correctly strip leading white-space from markdown

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -43,10 +43,10 @@
 			leadingTabs = text.match( /^\n?(\t*)/ )[1].length;
 
 		if( leadingTabs > 0 ) {
-			text = text.replace( new RegExp('\\n?\\t{' + leadingTabs + '}','g'), '\n' );
+			text = text.replace( new RegExp('\\n?\\t{' + leadingTabs + '}(.*)','g'), function(m, p1) { return '\n' + p1 ; } );
 		}
 		else if( leadingWs > 1 ) {
-			text = text.replace( new RegExp('\\n? {' + leadingWs + '}', 'g'), '\n' );
+			text = text.replace( new RegExp('\\n? {' + leadingWs + '}(.*)', 'g'), function(m, p1) { return '\n' + p1 ; } );
 		}
 
 		return text;


### PR DESCRIPTION
If the markdown contains something that is indented by more that the `leadingTabs`/`leadingWs` then extra white space is incorrectly removed. ie the following example:

```
    <section data-markdown>
    some text
       indented text
          more indented text
    </section>
```

would result in the following markdown:

```
some text
   indented text
  more indented text
```

We can work around this problem by using a function to generate the
replace value.