### PR TITLE
Allow whitespace on background-images, w3 compliance

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3085,7 +3085,7 @@
 
 				// Images
 				if( backgroundImage ) {
-					background.style.backgroundImage = 'url('+ backgroundImage +')';
+					background.style.backgroundImage = 'url('+ encodeURI(backgroundImage) +')';
 				}
 				// Videos
 				else if ( backgroundVideo && !isSpeakerNotes() ) {


### PR DESCRIPTION
https://www.w3.org/TR/CSS2/syndata.html#value-def-uri

Some characters appearing in an unquoted URI, such as parentheses, white space characters, single quotes (') and double quotes ("), must be escaped with a backslash so that the resulting URI value is a URI token: '\(', '\)'.