### PR TITLE
remove up and down arrows when disabled

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -243,6 +243,9 @@ body {
   border-bottom-width: 22px;
   border-bottom-color: #000; }
 
+.reveal .controls .navigate-up.hide {
+  display: none; }
+
 .reveal .controls .navigate-up.fragmented {
   opacity: 0.3; }
 
@@ -251,6 +254,9 @@ body {
   top: 74px;
   border-top-width: 22px;
   border-top-color: #000; }
+
+.reveal .controls .navigate-down.hide {
+  display: none; }
 
 .reveal .controls .navigate-down.fragmented {
   opacity: 0.3; }

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1446,7 +1446,7 @@
 	 * target element.
 	 *
 	 * remaining height = [ configured parent height ] - [ current parent height ]
-	 * 
+	 *
 	 * @param {HTMLElement} element
 	 * @param {number} [height]
 	 */
@@ -2829,11 +2829,15 @@
 			node.setAttribute( 'disabled', 'disabled' );
 		} );
 
+		// Add the 'hide' class to up and down routes if not available
+		if( !routes.up ) dom.controlsUp.forEach( function( el ) { el.classList.add( 'hide' ); } );
+		if( !routes.down ) dom.controlsDown.forEach( function( el ) { el.classList.add( 'hide' ); } );
+
 		// Add the 'enabled' class to the available routes; remove 'disabled' attribute to enable buttons
 		if( routes.left ) dom.controlsLeft.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); } );
 		if( routes.right ) dom.controlsRight.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); } );
-		if( routes.up ) dom.controlsUp.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); } );
-		if( routes.down ) dom.controlsDown.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); } );
+		if( routes.up ) dom.controlsUp.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); el.classList.remove( 'hide' ); } );
+		if( routes.down ) dom.controlsDown.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); el.classList.remove( 'hide' ); } );
 
 		// Prev/next buttons
 		if( routes.left || routes.up ) dom.controlsPrev.forEach( function( el ) { el.classList.add( 'enabled' ); el.removeAttribute( 'disabled' ); } );


### PR DESCRIPTION
This fixes #1839 by hiding the up and down arrow buttons when there is not a slide to move to.