### PR TITLE
print-pdf layout slide contents to fit stretch elements

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -614,6 +614,9 @@
 		document.body.style.width = pageWidth + 'px';
 		document.body.style.height = pageHeight + 'px';
 
+		// Make sure stretch elements fit on slide
+		layoutSlideContents(slideWidth, slideHeight);
+
 		// Add each slide's index as attributes on itself, we need these
 		// indices to generate slide numbers below
 		toArray( dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR ) ).forEach( function( hslide, h ) {


### PR DESCRIPTION
layout() and thereby layoutSlideContents() is never invoked
when isPrintingPdf() is true so stretch elements are not
sized correctly.
This is ensured now by invoking the layoutSlideContents
from SetupPDF(). There seems no need to scale down
like in other PR's is suggested.