### PR TITLE
page break after pdf-page iso section

### DIFF
--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -84,14 +84,13 @@ ul, ol, div, p {
 }
 
 .reveal .slides .pdf-page {
+	page-break-after: always !important;
 	position: relative;
 	overflow: hidden;
 	z-index: 1;
 }
 
 .reveal .slides section {
-	page-break-after: always !important;
-
 	visibility: visible !important;
 	display: block !important;
 	position: relative !important;


### PR DESCRIPTION
By doing this it is also possible to generate a pdf using [wkhtmltopdf](wkhtmltopdf.org):

```
wkhtmltopdf -O Landscape --zoom 3.5 --window-status --javascript-delay 5000 -B 0 -L 0 -R 0 -T 0  "http://localhost:9000/?print-pdf"
```

I've tested it on printing from Chrome, printing using the phantomjs plugin and now also with wkhtmltopdf.