### PR TITLE
Normalizing whitespace in markdown might breaks nested lists

### DIFF
--- a/plugin/markdown/markdown.js
+++ b/plugin/markdown/markdown.js
@@ -39,7 +39,7 @@
 		// restore script end tags
 		text = text.replace( new RegExp( SCRIPT_END_PLACEHOLDER, 'g' ), '</script>' );
 
-		var leadingWs = text.match( /^\n?(\s*)/ )[1].length,
+		var leadingWs = text.match( /^\n?( *)/ )[1].length,
 			leadingTabs = text.match( /^\n?(\t*)/ )[1].length;
 
 		if( leadingTabs > 0 ) {


### PR DESCRIPTION
Normalizing whitespaces and tabs in markdown plugin might kill nested lists and break other GFM features. 

Example Markdown (notice the two empty lines in the beginning):
```


- A
  - A1
  - A2
- B
```

Expected Result:
- A
  - A1
  - A2
- B

Actual Result:
- A
- A1
- A2
- B

In Markdown.js the `getMarkdownFromSlide` function queries the text for leading whitespaces using `text.match( /^\n?(\s*)/ )[1].length`. By using the `\s`, the regex also matches empty lines.
In this example the two lines in the beginning. Unfortunately the nested list is also intended with two spaces and therefore gets flatted out.

This PR replaces the `\s` with an actual ` ` to correct this issue.