### PR TITLE
Fix data-background-video autoplay on iOS Safari

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1426,7 +1426,7 @@
 	 * target element.
 	 *
 	 * remaining height = [ configured parent height ] - [ current parent height ]
-	 * 
+	 *
 	 * @param {HTMLElement} element
 	 * @param {number} [height]
 	 */
@@ -3058,6 +3058,8 @@
 				// Videos
 				else if ( backgroundVideo && !isSpeakerNotes() ) {
 					var video = document.createElement( 'video' );
+					video.setAttribute( 'autoplay', '' );
+					video.setAttribute( 'playsinline', '' );
 
 					if( backgroundVideoLoop ) {
 						video.setAttribute( 'loop', '' );
@@ -3900,7 +3902,7 @@
 			// If there are media elements with data-autoplay,
 			// automatically set the autoSlide duration to the
 			// length of that media. Not applicable if the slide
-			// is divided up into fragments. 
+			// is divided up into fragments.
 			// playbackRate is accounted for in the duration.
 			if( currentSlide.querySelectorAll( '.fragment' ).length === 0 ) {
 				toArray( currentSlide.querySelectorAll( 'video, audio' ) ).forEach( function( el ) {


### PR DESCRIPTION
Add 'autoplay' and 'playsinline' attributes to data-background-video elements so that they autoplay on iOS Safari browser