### PR TITLE
Reset current time in Vimeo

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3411,6 +3411,7 @@
 			toArray( element.querySelectorAll( 'iframe[src*="player.vimeo.com/"]' ) ).forEach( function( el ) {
 				if( !el.hasAttribute( 'data-ignore' ) && el.contentWindow && typeof el.contentWindow.postMessage === 'function' ) {
 					el.contentWindow.postMessage( '{"method":"pause"}', '*' );
+					el.contentWindow.postMessage( '{"method":"setCurrentTime", "value":0}', '*' );
 				}
 			});
 


### PR DESCRIPTION
This reset the current time after pausing, so it start from the beginning the next time.

Not sure if the other video APIs also have this option.