### PR TITLE
New option in math object to define TeX macros

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -9,6 +9,7 @@ var RevealMath = window.RevealMath || (function(){
 	var options = Reveal.getConfig().math || {};
 	options.mathjax = options.mathjax || 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
+	options.macros = options.macros || {};
 
 	loadScript( options.mathjax + '?config=' + options.config, function() {
 
@@ -18,7 +19,10 @@ var RevealMath = window.RevealMath || (function(){
 				inlineMath: [['$','$'],['\\(','\\)']] ,
 				skipTags: ['script','noscript','style','textarea','pre']
 			},
-			skipStartupTypeset: true
+			skipStartupTypeset: true,
+			TeX: {
+				Macros: options.macros
+			}
 		});
 
 		// Typeset followed by an immediate reveal.js layout since


### PR DESCRIPTION
With this small edit, the `math` object we can define in the options can use the attribute `macros`. This attribute can be used to define TeX macros that will be available in all the slides. The syntax to use to define macros can be found in [MathJax's documentation](http://docs.mathjax.org/en/latest/tex.html#defining-tex-macros).

For example we define here a macro without argument and a macro with two arguments:
```js
Reveal.initialize({
	math: {
		macros: {
			R: '\\mathbb{R}',
			set: ['\\left\\{#1 \\; ; \\; #2\\right\\}', 2]
		}
	},

	dependencies: [
		{src: 'plugin/math/math.js', async: true}
	]
});
```

These macros can then be used in any slide:
```html
<section>
	Here is a common vector space:
	\[L^2(\R) = \set{u : \R \to \R}{\int_\R |u|^2 &lt; +\infty}\]
	used in functional analysis.
</section>
```