### PR TITLE
make gruntfile.js work with old version of node

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,10 +130,10 @@ module.exports = function(grunt) {
 				tasks: 'css-core'
 			},
 			html: {
-				files: root.map(path => path + '/*.html')
+                files: root.map(function(path) { return path + '/*.html';} )
 			},
 			markdown: {
-				files: root.map(path => path + '/*.md')
+                files: root.map(function(path) { return path + '/*.md'; })
 			},
 			options: {
 				livereload: true


### PR DESCRIPTION
This is the pull request for issue 1857, which make gruntfile.js works with old version of node.js. 
Can someone take a look? Thanks!