### PR TITLE
Change data background hash generation

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -882,16 +882,18 @@
 		// Create a hash for this combination of background settings.
 		// This is used to determine when two slide backgrounds are
 		// the same.
-		if( data.background || data.backgroundColor || data.backgroundImage || data.backgroundVideo || data.backgroundIframe ) {
-			element.setAttribute( 'data-background-hash', data.background +
-															data.backgroundSize +
-															data.backgroundImage +
-															data.backgroundVideo +
-															data.backgroundIframe +
-															data.backgroundColor +
-															data.backgroundRepeat +
-															data.backgroundPosition +
-															data.backgroundTransition );
+		var dataBackgroundHash = [data.background,
+									data.backgroundSize,
+									data.backgroundImage,
+									data.backgroundVideo,
+									data.backgroundIframe,
+									data.backgroundColor,
+									data.backgroundRepeat,
+									data.backgroundPosition,
+									data.backgroundTransition].filter(Boolean).join('');
+
+		if ( dataBackgroundHash ) {
+			element.setAttribute( 'data-background-hash', dataBackgroundHash);
 		}
 
 		// Additional and optional background properties


### PR DESCRIPTION
I saw an unexpected behavior in the data-background-hash generation.
I don't think that it is intended to have a multiple concatenation of "null".

In the demo.html, there is:
```
<section data-background="#dddddd">
```
which gives
```
data-background-hash="#ddddddnullnullnullnullnullnullnullnull"
```

I am a JavaScript beginner.
I saw that a way to prevent this is to use the `filter` method with the `Boolean` constructor.
I don't know which browsers are currently supported but `filter` is only available from IE9.