### PR TITLE
replace cdn.mathjax.org with cdnjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,7 +1137,7 @@ Reveal.initialize({
 	// other options ...
 
 	math: {
-		mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
+		mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
 		config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
 	},
 

--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -7,7 +7,7 @@
 var RevealMath = window.RevealMath || (function(){
 
 	var options = Reveal.getConfig().math || {};
-	options.mathjax = options.mathjax || 'https://cdn.mathjax.org/mathjax/latest/MathJax.js';
+	options.mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
 
 	loadScript( options.mathjax + '?config=' + options.config, function() {

--- a/test/examples/math.html
+++ b/test/examples/math.html
@@ -169,7 +169,7 @@
 				transition: 'linear',
 
 				math: {
-					// mathjax: 'http://cdn.mathjax.org/mathjax/latest/MathJax.js',
+					// mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
 					config: 'TeX-AMS_HTML-full'
 				},
 


### PR DESCRIPTION
cdn.mathjax.org is shutting down: https://www.mathjax.org/cdn-shutting-down/

This changes the default MathJax URL in the math plugin, as well as
references in README.md and test/examples/math.html