### PR TITLE
Fix printing when a transform is applied to slides

### DIFF
--- a/css/print/paper.css
+++ b/css/print/paper.css
@@ -124,6 +124,7 @@
 		margin-top: 0 !important;
 		padding: 0 !important;
 		zoom: 1 !important;
+		transform: none !important;
 
 		overflow: visible !important;
 		display: block !important;


### PR DESCRIPTION
If the authoring width and/or height are set in Reveal.initialize, Reveal applies a transform: CSS rule to the "slides" div. When printing this transformation needs to be overridden to avoid cutting off the printed text.