### PR TITLE
Remove logic of taking data-autoslide from the first available fragment

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3871,10 +3871,6 @@
 
 			var fragment = currentSlide.querySelector( '.current-fragment' );
 
-			// When the slide first appears there is no "current" fragment so
-			// we look for a data-autoslide timing on the first fragment
-			if( !fragment ) fragment = currentSlide.querySelector( '.fragment' );
-
 			var fragmentAutoSlide = fragment ? fragment.getAttribute( 'data-autoslide' ) : null;
 			var parentAutoSlide = currentSlide.parentNode ? currentSlide.parentNode.getAttribute( 'data-autoslide' ) : null;
 			var slideAutoSlide = currentSlide.getAttribute( 'data-autoslide' );


### PR DESCRIPTION

This logic makes the following scenario impossible:

```html
<section data-autoslide="1000">
  <h2>Hello!</h2>
  <p>This page contains fragments. The first fragment will appear after 1 second:</p>
  <p class="fragment current-visible" data-autoslide="5000">
    This text is visible for 5 seconds, and then disappears.
  </p>
  <p class="fragment" data-autoslide="2000">
    This text is visible for 2 seconds before navigating to the next slide.
  </p>
</section>
```

Instead, the first fragment appears after 5 seconds, and stays visible for another 5 seconds. I couldn't find an easy way to make it work except adding an empty fragment with `data-autoslide="500"`, i.e. half a second, so it appears after 0.5 seconds and moves on in another 0.5 seconds.

Perhaps you could delete this piece of code? Will it break anything?

Thanks!
