### PR TITLE
adds `useAvailablePort` option when serving page with connect.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,7 +95,8 @@ module.exports = function(grunt) {
 					port: port,
 					base: base,
 					livereload: true,
-					open: true
+					open: true,
+					useAvailablePort: true
 				}
 			}
 		},


### PR DESCRIPTION
I frequently have to specify a port because `8000` is taken. This feature should help out with that. 