### PR TITLE
Allow multiplexing on URL load

### DIFF
--- a/plugin/multiplex/master.js
+++ b/plugin/multiplex/master.js
@@ -19,6 +19,9 @@
 
 	};
 
+	// post once the page is loaded, so the client follows also on "open URL".
+	window.onload = post;
+
 	// Monitor events that trigger a change in state
 	Reveal.addEventListener( 'slidechanged', post );
 	Reveal.addEventListener( 'fragmentshown', post );


### PR DESCRIPTION
This fixes [issue 1896](https://github.com/hakimel/reveal.js/issues/1896).

The multiplexing now also works on opening URLs. This allows the links to be used as a remote control to jump to specific slides.

Are there any concerns with this approach?