### PR TITLE
allow specifying MathJax config with ?config=

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -10,7 +10,12 @@ var RevealMath = window.RevealMath || (function(){
 	options.mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
 
-	loadScript( options.mathjax + '?config=' + options.config, function() {
+	var url = options.mathjax;
+	if (url.indexOf('?config=') == -1) {
+		url += '?config=' + options.config;
+	}
+
+	loadScript( url, function() {
 
 		MathJax.Hub.Config({
 			messageStyle: 'none',


### PR DESCRIPTION
I want to specify MathJax configuration in the url.
This feature would be nice to have for using reveal.js with pandoc.