### PR TITLE
PDF export: add option to export one page per fragment

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -734,19 +734,19 @@
 					var numberOfFragments = toArray( page.querySelectorAll( '.fragment' ) ).length;
 
 					for ( var currentFragment = 0; currentFragment < numberOfFragments; currentFragment++ ) {
-                        var clonedPage = page.cloneNode( true );
-                        page.parentNode.insertBefore( clonedPage, page.nextSibling );
+						var clonedPage = page.cloneNode( true );
+						page.parentNode.insertBefore( clonedPage, page.nextSibling );
 
-                        toArray( sortFragments( clonedPage.querySelectorAll( '.fragment' ))).forEach( function ( fragment, fragmentIndex ) {
-                            if ( fragmentIndex <= currentFragment ) {
-                                fragment.classList.add( 'visible' );
-                            } else {
-                                fragment.classList.remove( 'visible' );
-                            }
-                        } );
+						toArray( sortFragments( clonedPage.querySelectorAll( '.fragment' ))).forEach( function ( fragment, fragmentIndex ) {
+							if ( fragmentIndex <= currentFragment ) {
+								fragment.classList.add( 'visible' );
+							} else {
+								fragment.classList.remove( 'visible' );
+							}
+						} );
 
-                        page = clonedPage;
-                    }
+						page = clonedPage;
+					}
 
 				}
 				// Show all fragments
@@ -1522,12 +1522,12 @@
 
 	}
 
-    /**
+	/**
 	 * Check if this instance is being used to print a PDF with fragments.
-     */
-    function isPrintingPDFFragments() {
+	 */
+	function isPrintingPDFFragments() {
 
-    	return ( /print-pdf-fragments/gi ).test( window.location.search );
+		return ( /print-pdf-fragments/gi ).test( window.location.search );
 
 	}
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -727,14 +727,39 @@
 					numberElement.innerHTML = formatSlideNumber( slideNumberH, '.', slideNumberV );
 					page.appendChild( numberElement );
 				}
+
+				// Copy page and show fragments one after another
+				if ( isPrintingPDFFragments() ) {
+
+					var numberOfFragments = toArray( page.querySelectorAll( '.fragment' ) ).length;
+
+					for ( var currentFragment = 0; currentFragment < numberOfFragments; currentFragment++ ) {
+                        var clonedPage = page.cloneNode( true );
+                        page.parentNode.insertBefore( clonedPage, page.nextSibling );
+
+                        toArray( sortFragments( clonedPage.querySelectorAll( '.fragment' ))).forEach( function ( fragment, fragmentIndex ) {
+                            if ( fragmentIndex <= currentFragment ) {
+                                fragment.classList.add( 'visible' );
+                            } else {
+                                fragment.classList.remove( 'visible' );
+                            }
+                        } );
+
+                        page = clonedPage;
+                    }
+
+				}
+				// Show all fragments
+				else {
+					toArray( page.querySelectorAll( '.fragment' ) ).forEach( function( fragment ) {
+						fragment.classList.add( 'visible' );
+					} );
+				}
+
 			}
 
 		} );
 
-		// Show all fragments
-		toArray( dom.wrapper.querySelectorAll( SLIDES_SELECTOR + ' .fragment' ) ).forEach( function( fragment ) {
-			fragment.classList.add( 'visible' );
-		} );
 
 		// Notify subscribers that the PDF layout is good to go
 		dispatchEvent( 'pdf-ready' );
@@ -1494,6 +1519,15 @@
 	function isPrintingPDF() {
 
 		return ( /print-pdf/gi ).test( window.location.search );
+
+	}
+
+    /**
+	 * Check if this instance is being used to print a PDF with fragments.
+     */
+    function isPrintingPDFFragments() {
+
+    	return ( /print-pdf-fragments/gi ).test( window.location.search );
 
 	}
 


### PR DESCRIPTION
Allows to export one PDF page per fragment by appending `?pdf-print-fragments` to the URL.

Fix issue: #1584 