### PR TITLE
Block F5 in speaker notes window, avoid disconnects

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -427,10 +427,16 @@
 				 * Forward keyboard events to the current slide window.
 				 * This enables keyboard events to work even if focus
 				 * isn't set on the current slide iframe.
+				 *
+				 * Block F5 default handling, it reloads and disconnects
+				 * the speaker notes window.
 				 */
 				function setupKeyboard() {
 
 					document.addEventListener( 'keydown', function( event ) {
+						if (event.keyCode === 116) {
+							event.preventDefault();
+						}
 						currentSlide.contentWindow.postMessage( JSON.stringify({ method: 'triggerKey', args: [ event.keyCode ] }), '*' );
 					} );
 


### PR DESCRIPTION
I noticed that because my presenter sends [F5] as presentation start key. 