### PR TITLE
Changed a selector that was breaking print mode.

### DIFF
--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -30,8 +30,8 @@ body {
   background: #98bdef;
   text-shadow: none; }
 
-.reveal .slides > section,
-.reveal .slides > section > section {
+.reveal .slides section,
+.reveal .slides section > section {
   line-height: 1.3;
   font-weight: inherit; }
 


### PR DESCRIPTION
The old CSS selector failed to set the styled elements in print mode due to how the structure of the HTML changes. This problem appears to exist in other themes as well.