### PR TITLE
Prevent text-transform inside code tags

### DIFF
--- a/css/theme/beige.css
+++ b/css/theme/beige.css
@@ -160,7 +160,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/black.css
+++ b/css/theme/black.css
@@ -156,7 +156,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/blood.css
+++ b/css/theme/blood.css
@@ -159,7 +159,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/league.css
+++ b/css/theme/league.css
@@ -162,7 +162,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/moon.css
+++ b/css/theme/moon.css
@@ -160,7 +160,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/night.css
+++ b/css/theme/night.css
@@ -154,7 +154,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/serif.css
+++ b/css/theme/serif.css
@@ -156,7 +156,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/simple.css
+++ b/css/theme/simple.css
@@ -159,7 +159,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/sky.css
+++ b/css/theme/sky.css
@@ -163,7 +163,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/solarized.css
+++ b/css/theme/solarized.css
@@ -160,7 +160,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -174,8 +174,10 @@ body {
 
 	box-shadow: 0px 0px 6px rgba(0,0,0,0.3);
 }
+
 .reveal code {
 	font-family: monospace;
+	text-transform: none;
 }
 
 .reveal pre code {

--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -156,7 +156,8 @@ body {
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
 
 .reveal code {
-  font-family: monospace; }
+  font-family: monospace;
+  text-transform: none; }
 
 .reveal pre code {
   display: block;


### PR DESCRIPTION
This removes ```text-transform: uppercase;``` from within ```<code>``` even if they are used inside a header tag. This is in reference to issue #1970