### PR TITLE
Math macros

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -9,6 +9,7 @@ var RevealMath = window.RevealMath || (function(){
 	var options = Reveal.getConfig().math || {};
 	options.mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
+	options.macros = options.macros || {};
 
 	loadScript( options.mathjax + '?config=' + options.config, function() {
 
@@ -18,7 +19,10 @@ var RevealMath = window.RevealMath || (function(){
 				inlineMath: [['$','$'],['\\(','\\)']] ,
 				skipTags: ['script','noscript','style','textarea','pre']
 			},
-			skipStartupTypeset: true
+			skipStartupTypeset: true,
+			TeX: {
+				Macros: options.macros
+			}
 		});
 
 		// Typeset followed by an immediate reveal.js layout since


### PR DESCRIPTION
With this change, we can define TeX macros that can be used in all the slides. These macros can be defined with the new `macros` attribute of the `math` option of Reveal.js. The syntax for defining the macros is the same as [the one used by MathJax](http://docs.mathjax.org/en/latest/tex.html#defining-tex-macros).

For example we define here a macro without argument and a macro with two arguments:
```js
Reveal.initialize({
	math: {
		macros: {
			R: '\\mathbb{R}',
			set: ['\\left\\{#1 \\; ; \\; #2\\right\\}', 2]
		}
	},

	dependencies: [
		{src: 'plugin/math/math.js', async: true}
	]
});
```

These macros can then be used in any slide:
```html
<section>
	Here is a common vector space:
	\[L^2(\R) = \set{u : \R \to \R}{\int_\R |u|^2 &lt; +\infty}\]
	used in functional analysis.
</section>
```