### PR TITLE
font-variant vs text-transform

### DIFF
--- a/css/theme/template/settings.scss
+++ b/css/theme/template/settings.scss
@@ -18,9 +18,10 @@ $headingFont: 'League Gothic', Impact, sans-serif;
 $headingColor: #eee;
 $headingLineHeight: 1.2;
 $headingLetterSpacing: normal;
-$headingTextTransform: uppercase;
+$headingTextTransform: normal;
 $headingTextShadow: none;
 $headingFontWeight: normal;
+$headingFontVariant: small-caps;
 $heading1TextShadow: $headingTextShadow;
 
 $heading1Size: 3.77em;

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -49,6 +49,7 @@ body {
 
 	font-family: $headingFont;
 	font-weight: $headingFontWeight;
+	font-variant: $headingFontVariant;
 	line-height: $headingLineHeight;
 	letter-spacing: $headingLetterSpacing;
 


### PR DESCRIPTION
Using the `small-caps` font-variant rather than the `uppercase` text-transform attribute for the headings.