### PR TITLE
Introducing support for speaker notes for each slide fragment

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3898,6 +3898,14 @@
 		if( notesElement ) {
 			return notesElement.innerHTML;
 		}
+		else {
+			var fragmentElement = currentSlide.querySelector( '.current-fragment' );
+
+			// In case there are fragment notes
+			if( fragmentElement && fragmentElement.hasAttribute( 'data-notes' ) ) {
+				return fragmentElement.getAttribute( 'data-notes' );
+			}
+		}
 
 		return null;
 
@@ -4090,6 +4098,7 @@
 
 				updateControls();
 				updateProgress();
+				updateNotes();
 
 				return !!( fragmentsShown.length || fragmentsHidden.length );
 


### PR DESCRIPTION
The presentation may now update the speaker notes with information about the
fragment being displayed on the slide. Previously, the speaker notes could only
be displayed for all fragments of a slide. This might be too much information
for slides that contain multiple fragments.