### PR TITLE
Export isSpeakerNotes

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -5104,6 +5104,7 @@
 		isOverview: isOverview,
 		isPaused: isPaused,
 		isAutoSliding: isAutoSliding,
+		isSpeakerNotes: isSpeakerNotes,
 
 		// Adds or removes all internal event listeners (such as keyboard)
 		addEventListeners: addEventListeners,


### PR DESCRIPTION
Export `isSpeakerNotes`, which is useful to avoid multiple audio players, e.g., with the audio-slideshow plugin.