### PR TITLE
Register search key shortcut for help overlay

### DIFF
--- a/plugin/search/search.js
+++ b/plugin/search/search.js
@@ -200,6 +200,7 @@ function Hilitor(id, tag)
 			toggleSearch();
 		}
 	}, false );
+	if( window.Reveal ) Reveal.registerKeyboardShortcut( 'Ctrl-Shift-F', 'Search' );
 	closeSearch();
 	return { open: openSearch };
 })();


### PR DESCRIPTION
Currently, the search keyboard shortcut does not appear in the help overlay. This PR registers it.