### PR TITLE
add multi-column support (incl. readme and demo.html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ reveal.js comes with a broad range of features including [nested slides](https:/
   - [Parallax Background](#parallax-background)
   - [Slide Transitions](#slide-transitions)
   - [Internal links](#internal-links)
+  - [Multi Column](#multi-column)
   - [Fragments](#fragments)
   - [Fragment events](#fragment-events)
   - [Code syntax highlighting](#code-syntax-highlighting)
@@ -702,6 +703,36 @@ You can also add relative navigation links, similar to the built in reveal.js co
 <a href="#" class="navigate-down">
 <a href="#" class="navigate-prev"> <!-- Previous vertical or horizontal slide -->
 <a href="#" class="navigate-next"> <!-- Next vertical or horizontal slide -->
+```
+
+### Multi Column
+
+It's easy to have a two- or even three-column layout for your whole or only part of your slide. With full-width text or headlines inbetween.
+
+No float is used, no clearfix is needed.
+
+```html
+<section>
+	<h2>Multi-Column Support</h2>
+	<div class='multi-col'>
+		<div class='col'>
+			This is column one of two columns.
+		</div>
+		<div class='col'>
+			...and column two, containing a list:
+			<ul class='col'>
+				<li>no float needed</li>
+				<li>no clearfix needed</li>
+			</ul>
+		</div>
+	</div>
+	<h4>With the very same classes, you can also have 3 or more columns:</h4>
+	<div class='multi-col'>
+		<div class='col'>Also works for three columns...</div>
+		<div class='col'>...as we can show in...</div>
+		<div class='col'>...this example here.</div>
+	</div>
+</section>
 ```
 
 

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -416,6 +416,25 @@ body {
     margin-left: -1.8em; } }
 
 /*********************************************
+ * MULTI COLUMN
+ *********************************************/
+.reveal .multi-col {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+  text-align: left; }
+  .reveal .multi-col .col {
+    position: relative;
+    display: table-cell;
+    vertical-align: top;
+    width: 50%;
+    padding: 1% 0 2% 3%; }
+    .reveal .multi-col .col:first-of-type {
+      padding-left: 0; }
+  .reveal .multi-col ul.col {
+    padding-left: 1em !important; }
+
+/*********************************************
  * PROGRESS BAR
  *********************************************/
 .reveal .progress {

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -503,6 +503,32 @@ $controlsArrowAngleActive: 36deg;
 
 
 /*********************************************
+ * MULTI COLUMN
+ *********************************************/
+
+ .reveal .multi-col {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	text-align: left; // centered does not look good on cols
+
+	.col {
+		position: relative; // just in case of absolute positioned children
+		display: table-cell;
+		vertical-align: top; // yes, a needed override
+		width: 50%;
+		padding: 1% 0 2% 3%;
+		&:first-of-type {
+			padding-left: 0; // nothing is left of column one
+		}
+	}
+
+	ul.col {
+		padding-left: 1em !important;
+	}
+}
+
+/*********************************************
  * PROGRESS BAR
  *********************************************/
 

--- a/demo.html
+++ b/demo.html
@@ -244,6 +244,30 @@ function linkify( selector ) {
 				</section>
 
 				<section>
+					<h2>Multi-Column Support</h2>
+					<div class='multi-col'>
+						<div class='col'>
+							This is column one of two columns. That usually resides on the left...
+						</div>
+						<div class='col'>
+							...and column two on the other side.
+							<ul class='col'>
+								<li>no float needed</li>
+								<li>no clearfix needed</li>
+							</ul>
+						</div>
+
+					</div>
+					<h4>...with the very same classes, you can also have 3 or even 4 columns:</h4>
+					<div class='multi-col'>
+						<div class='col'>Also works for three columns...</div>
+						<div class='col'>...as we can show in...</div>
+						<div class='col'>...this example here.</div>
+					</div>
+
+				</section>
+
+				<section>
 					<h2>Marvelous List</h2>
 					<ul>
 						<li>No order here</li>


### PR DESCRIPTION
very simple classes (not a huge grid system) for multi-column support.

![selection_178](https://user-images.githubusercontent.com/21154106/32450284-214b8002-c314-11e7-9e79-56585915d41c.png)

    <h4>...with the very same classes, you can also have 3 or even 4 columns:</h4>
    <div class='multi-col'>
        <div class='col'>Also works for three columns...</div>
        <div class='col'>...as we can show in...</div>
        <div class='col'>...this example here.</div>
    </div>