### PR TITLE
URI encode name hash

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3563,10 +3563,11 @@
 			var element;
 
 			// Ensure the named link is a valid HTML ID attribute
-			if( /^[a-zA-Z][\w:.-]*$/.test( name ) ) {
-				// Find the slide with the specified ID
-				element = document.getElementById( name );
-			}
+			try {
+				element = document.getElementById( decodeURIComponent( name ) );
+                        }
+			catch (e) {
+                        }
 
 			if( element ) {
 				// Find the position of the named slide and navigate to it
@@ -3614,7 +3615,7 @@
 				// Attempt to create a named link based on the slide's ID
 				var id = currentSlide.getAttribute( 'id' );
 				if( id ) {
-					id = id.replace( /[^a-zA-Z0-9\-\_\:\.]/g, '' );
+					id = encodeURIComponent( id );
 				}
 
 				// If the current slide has an ID, use that as a named link


### PR DESCRIPTION
Named link derived from slide id attributes with accentuated or special characters can't be found back in the slideshow when reading a URL. For instance the id "lemon-soufflé" produces the hash "lemon-souffl" which, when entered, can't be linked to the correct slide. The fix proposed in this PR consists in URI encoding the id value to form the hash and URI decoding the hash to locate the slide by its id.
This is linked to issue [1346](https://github.com/hakimel/reveal.js/issues/1346) and related issues.