### PR TITLE
Allow tex2jax options to be passed into math plugin.

### DIFF
--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -9,15 +9,15 @@ var RevealMath = window.RevealMath || (function(){
 	var options = Reveal.getConfig().math || {};
 	options.mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
 	options.config = options.config || 'TeX-AMS_HTML-full';
+	options.tex2jax = options.tex2jax || {
+				inlineMath: [['$','$'],['\\(','\\)']] ,
+				skipTags: ['script','noscript','style','textarea','pre'] };
 
 	loadScript( options.mathjax + '?config=' + options.config, function() {
 
 		MathJax.Hub.Config({
 			messageStyle: 'none',
-			tex2jax: {
-				inlineMath: [['$','$'],['\\(','\\)']] ,
-				skipTags: ['script','noscript','style','textarea','pre']
-			},
+			tex2jax: options.tex2jax,
 			skipStartupTypeset: true
 		});
 


### PR DESCRIPTION
Closes #2026.

This does not change the default behavior of the math plugin,
but it allows $ delimiters to be disabled (which is usually
what you want, since otherwise normal uses of $ for currency get
treated as math delimiters).

To use:

    Reveal.initialize({
      math: {
        tex2jax: { inlineMath: [['\\(','\\)']],
                   skipTags: ['script','noscript','style',
                              'textarea','pre'] }
            },
      etc.
      });