### PR TITLE
 Update License Copyright Range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2017 Hakim El Hattab, http://hakim.se, and reveal.js contributors
+Copyright (C) 2012 - present Hakim El Hattab, http://hakim.se, and reveal.js contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2012 - present Hakim El Hattab, http://hakim.se, and reveal.js contributors
+Copyright (C) 2011 - present Hakim El Hattab, http://hakim.se, and reveal.js contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The Copyright should range from the date of licensing (which is commit [7379fb3](https://github.com/hakimel/reveal.js/commit/7379fb3652189e0789ab6b9466616a6f0e461642#diff-9879d6db96fd29134fc802214163b95a)) on _Jun 7, 2011 till the present_.