### PR TITLE
optionally put the fragment in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ Reveal.initialize({
 	// Turns fragments on and off globally
 	fragments: true,
 
+	// Flags whether to include the current fragment in the URL,
+	// so that reloading brings you to the same fragment position
+	fragmentInURL: false,
+
 	// Flags if the presentation is running in an embedded mode,
 	// i.e. contained within a limited portion of the screen
 	embedded: false,

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -102,6 +102,10 @@
 			// Turns fragments on and off globally
 			fragments: true,
 
+			// Flags whether to include the current fragment in the URL,
+			// so that reloading brings you to the same fragment position
+			fragmentInURL: false,
+
 			// Flags if the presentation is running in an embedded mode,
 			// i.e. contained within a limited portion of the screen
 			embedded: false,
@@ -3709,10 +3713,14 @@
 		else {
 			// Read the index components of the hash
 			var h = parseInt( bits[0], 10 ) || 0,
-				v = parseInt( bits[1], 10 ) || 0;
+				v = parseInt( bits[1], 10 ) || 0,
+				f;
+			if( config.fragmentInURL ) {
+				f = parseInt( bits[2], 10 ) || undefined;
+			}
 
-			if( h !== indexh || v !== indexv ) {
-				slide( h, v );
+			if( h !== indexh || v !== indexv || f !== undefined ) {
+				slide( h, v, f );
 			}
 		}
 
@@ -3745,14 +3753,21 @@
 					id = id.replace( /[^a-zA-Z0-9\-\_\:\.]/g, '' );
 				}
 
-				// If the current slide has an ID, use that as a named link
-				if( typeof id === 'string' && id.length ) {
+				var indexf;
+				if( config.fragmentInURL ) {
+					indexf = getIndices().f;
+				}
+
+				// If the current slide has an ID, use that as a named link,
+				// but we don't support named links with a fragment index
+				if( typeof id === 'string' && id.length && indexf === undefined ) {
 					url = '/' + id;
 				}
 				// Otherwise use the /h/v index
 				else {
-					if( indexh > 0 || indexv > 0 ) url += indexh;
-					if( indexv > 0 ) url += '/' + indexv;
+					if( indexh > 0 || indexv > 0 || indexf !== undefined ) url += indexh;
+					if( indexv > 0 || indexf !== undefined ) url += '/' + indexv;
+					if( indexf !== undefined ) url += '/' + indexf;
 				}
 
 				window.location.hash = url;
@@ -4089,6 +4104,9 @@
 
 				updateControls();
 				updateProgress();
+				if( config.fragmentInURL ) {
+					writeURL();
+				}
 
 				return !!( fragmentsShown.length || fragmentsHidden.length );
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3716,7 +3716,10 @@
 				v = parseInt( bits[1], 10 ) || 0,
 				f;
 			if( config.fragmentInURL ) {
-				f = parseInt( bits[2], 10 ) || undefined;
+				f = parseInt( bits[2], 10 );
+				if( isNaN( f ) ) {
+					f = undefined;
+				}
 			}
 
 			if( h !== indexh || v !== indexv || f !== undefined ) {


### PR DESCRIPTION
If you're editing a presentation with fragments, using livereload becomes annoying: after each change, you need to click through the fragments to where you were before. This PR greatly improves that by optionally including the current fragment index in the URL, so that you only have to click around if you're changing the fragment order (similarly to how you have to click around if you add/remove slides).

This is hidden behind a new configuration option `fragmentInURL` (default `false`), since not everyone will want fragments cluttering up their browser history (https://github.com/hakimel/reveal.js/pull/228#issuecomment-10261098).
  
This has been requested a couple of times: #228, #1125, #1919. By putting it behind a configuration option, I think it makes life much nicer for people using livereload while also not changing things at all for those who don't want it.
  