### PR TITLE
Allow JS files with query strings to be loaded.

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -418,7 +418,7 @@
 		}
 
 		function loadScript( s ) {
-			head.ready( s.src.match( /([\w\d_\-]*)\.?js$|[^\\\/]*$/i )[0], function() {
+			head.ready( s.src.match( /([\w\d_\-]*)\.?js(\?[\w\d.=&]*)?$|[^\\\/]*$/i )[0], function() {
 				// Extension may contain callback functions
 				if( typeof s.callback === 'function' ) {
 					s.callback.apply( this );


### PR DESCRIPTION
Fixes #1944.