### PR TITLE
Allow `data-background` images to load even if there is whitespace at…

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -916,7 +916,7 @@
 
 		if( data.background ) {
 			// Auto-wrap image urls in url(...)
-			if( /^(http|file|\/\/)/gi.test( data.background ) || /\.(svg|png|jpg|jpeg|gif|bmp)([?#]|$)/gi.test( data.background ) ) {
+			if( /^(http|file|\/\/)/gi.test( data.background ) || /\.(svg|png|jpg|jpeg|gif|bmp)([?#\s]|$)/gi.test( data.background ) ) {
 				slide.setAttribute( 'data-background-image', data.background );
 			}
 			else {


### PR DESCRIPTION
… the end.

Fixes #2032.