### PR TITLE
Allow users to customise MathJax options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,8 @@ Reveal.initialize({
 	math: {
 		mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
 		config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
+		// pass other options into `MathJax.Hub.Config()`
+		TeX: { Macros: macros }
 	},
 
 	dependencies: [

--- a/plugin/math/math.js
+++ b/plugin/math/math.js
@@ -7,19 +7,26 @@
 var RevealMath = window.RevealMath || (function(){
 
 	var options = Reveal.getConfig().math || {};
-	options.mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
-	options.config = options.config || 'TeX-AMS_HTML-full';
-	options.tex2jax = options.tex2jax || {
-				inlineMath: [['$','$'],['\\(','\\)']] ,
-				skipTags: ['script','noscript','style','textarea','pre'] };
+	var mathjax = options.mathjax || 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js';
+	var config = options.config || 'TeX-AMS_HTML-full';
+	var url = mathjax + '?config=' + config;
 
-	loadScript( options.mathjax + '?config=' + options.config, function() {
+	var defaultOptions = {
+		messageStyle: 'none',
+		tex2jax: {
+			inlineMath: [ [ '$', '$' ], [ '\\(', '\\)' ] ],
+			skipTags: [ 'script', 'noscript', 'style', 'textarea', 'pre' ]
+		},
+		skipStartupTypeset: true
+	};
 
-		MathJax.Hub.Config({
-			messageStyle: 'none',
-			tex2jax: options.tex2jax,
-			skipStartupTypeset: true
-		});
+	defaults( options, defaultOptions );
+	defaults( options.tex2jax, defaultOptions.tex2jax );
+	options.mathjax = options.config = null;
+
+	loadScript( url, function() {
+
+		MathJax.Hub.Config( options );
 
 		// Typeset followed by an immediate reveal.js layout since
 		// the typesetting process could affect slide height
@@ -34,6 +41,16 @@ var RevealMath = window.RevealMath || (function(){
 		} );
 
 	} );
+
+	function defaults( options, defaultOptions ) {
+
+		for ( var i in defaultOptions ) {
+			if ( !options.hasOwnProperty( i ) ) {
+				options[i] = defaultOptions[i];
+			}
+		}
+
+	}
 
 	function loadScript( url, callback ) {
 

--- a/test/examples/math.html
+++ b/test/examples/math.html
@@ -83,6 +83,14 @@
 				</section>
 
 				<section>
+					<h3>TeX Macros</h3>
+
+					Here is a common vector space:
+					\[L^2(\R) = \set{u : \R \to \R}{\int_\R |u|^2 &lt; +\infty}\]
+					used in functional analysis.
+				</section>
+
+				<section>
 					<section>
 						<h3>The Lorenz Equations</h3>
 
@@ -153,6 +161,14 @@
 							\]
 						</div>
 					</section>
+
+					<section>
+						<h3>TeX Macros</h3>
+
+						Here is a common vector space:
+						\[L^2(\R) = \set{u : \R \to \R}{\int_\R |u|^2 &lt; +\infty}\]
+						used in functional analysis.
+					</section>
 				</section>
 
 			</div>
@@ -170,7 +186,13 @@
 
 				math: {
 					// mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
-					config: 'TeX-AMS_HTML-full'
+					config: 'TeX-AMS_HTML-full',
+					TeX: {
+						Macros: {
+							R: '\\mathbb{R}',
+							set: [ '\\left\\{#1 \\; ; \\; #2\\right\\}', 2 ]
+						}
+					}
 				},
 
 				dependencies: [


### PR DESCRIPTION
Ref. #1856, #2006, #2045.

This is a more open approach to allow customisation of all MathJax options instead of select options only.