### PR TITLE
Custom message posting for speaker notes window

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3760,7 +3760,9 @@
 	 * If the soeakers notes are not open this returns null. 
 	 */
 	function getSpeakerNotesWindow() {
+
 		return null;
+		
 	}
 
 	/**

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3756,6 +3756,14 @@
 	}
 
 	/**
+	 * Returns the speaker notes Window object if it is open.
+	 * If the soeakers notes are not open this returns null. 
+	 */
+	function getSpeakerNotesWindow() {
+		return null;
+	}
+
+	/**
 	 * Reads the current URL (hash) and navigates accordingly.
 	 */
 	function readURL() {
@@ -5244,6 +5252,7 @@
 		isPaused: isPaused,
 		isAutoSliding: isAutoSliding,
 		isSpeakerNotes: isSpeakerNotes,
+		getSpeakerNotesWindow: getSpeakerNotesWindow,
 
 		// Slide preloading
 		loadSlide: loadSlide,

--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -356,6 +356,11 @@
 						else if( data.type === 'state' ) {
 							handleStateMessage( data );
 						}
+						// otherwise, if type is a non-empty string post directly to note slides
+						else if( typeof data.type === 'string' && !(data.type.length === 0 || !data.type.trim())) {
+							currentSlide.contentWindow.postMessage( event.data, '*' );
+							upcomingSlide.contentWindow.postMessage( event.data, '*' );
+						}
 					}
 					// Messages sent by the reveal.js inside of the current slide preview
 					else if( data && data.namespace === 'reveal' ) {
@@ -367,6 +372,10 @@
 
 							window.opener.postMessage( JSON.stringify({ method: 'setState', args: [ data.state ]} ), '*' );
 
+						}
+						// otherwise, if eventName is a non-empty string post directly to main presentation
+						else if( typeof data.eventName === 'string' && !(data.eventName.length === 0 || !data.eventName.trim())) {
+							window.opener.postMessage( event.data, '*' );
 						}
 					}
 

--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -23,7 +23,7 @@ var RevealNotes = (function() {
 
 		// Allow popup window access to Reveal API
 		notesPopup.Reveal = this.Reveal;
-		this.Reveal.speakerNotesWindow = notesPopup;
+		this.Reveal.getSpeakerNotesWindow = function() { return notesPopup.window  };
 
 		/**
 		 * Connect to the notes window through a postmessage handshake.

--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -23,6 +23,7 @@ var RevealNotes = (function() {
 
 		// Allow popup window access to Reveal API
 		notesPopup.Reveal = this.Reveal;
+		this.Reveal.speakerNotesWindow = notesPopup;
 
 		/**
 		 * Connect to the notes window through a postmessage handshake.


### PR DESCRIPTION
There is currently no mechanism for a plugin to pass messages between the presentation and the speaker notes. This PR allows a plugin to communicate with itself via `postMessage()` using the 'reveal' and 'reveal-notes' namespaces.

My specific use case is keeping the theme/transition changes consistent across views when using the reveal.js-menu plugin (https://github.com/denehyg/reveal.js-menu/issues/19), but this should allow any plugin to share state/events between views. For example, it should enable a chalkboard plugin to share overlay data so that notes added to one view could be replicated in the other.