### PR TITLE
Clarify the meaning of the notes?: regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This is based on [data-markdown](https://gist.github.com/1343518) from [Paul Iri
 
 #### External Markdown
 
-You can write your content as a separate file and have reveal.js load it at runtime. Note the separator arguments which determine how slides are delimited in the external file: the `data-separator` attribute defines a regular expression for horizontal slides (defaults to `^\r?\n---\r?\n$`, a newline-bounded horizontal rule)  and `data-separator-vertical` defines vertical slides (disabled by default). The `data-separator-notes` attribute is a regular expression for specifying the beginning of the current slide's speaker notes (defaults to `notes?:`). The `data-charset` attribute is optional and specifies which charset to use when loading the external file.
+You can write your content as a separate file and have reveal.js load it at runtime. Note the separator arguments which determine how slides are delimited in the external file: the `data-separator` attribute defines a regular expression for horizontal slides (defaults to `^\r?\n---\r?\n$`, a newline-bounded horizontal rule)  and `data-separator-vertical` defines vertical slides (disabled by default). The `data-separator-notes` attribute is a regular expression for specifying the beginning of the current slide's speaker notes (defaults to `notes?:`, so it will match both "note:" and "notes:"). The `data-charset` attribute is optional and specifies which charset to use when loading the external file.
 
 When used locally, this feature requires that reveal.js [runs from a local web server](#full-setup).  The following example customises all available options:
 


### PR DESCRIPTION
When I read that the default notes separator in markdown files is `notes?:`, I took it too literally and put `notes?:` in my markdown, which of course did not work. Unfortunately it took me a debugger to realize why I was wrong.

Going back to the documentation, I noticed that it does say that the notes separator is interpreted as a regex. Although the documentation is not wrong, it didn't help me understand what the default separator actually means. Hopefully this pull request will prevent others from making the same mistake.