### PR TITLE
Added 'passive' to progress option to prevent mouse click handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ Reveal.initialize({
 	// or "visible"
 	controlsBackArrows: 'faded',
 
-	// Display a presentation progress bar
+	// Display a presentation progress bar.
+	// Set to false to hide the progress bar. To prevent slide
+	// changes on mouse click set to 'passive'.
 	progress: true,
 
 	// Display the page number of the current slide

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1201,7 +1201,7 @@
 			document.addEventListener( 'keypress', onDocumentKeyPress, false );
 		}
 
-		if( config.progress && dom.progress ) {
+		if( config.progress && config.progress !== 'passive' && dom.progress ) {
 			dom.progress.addEventListener( 'click', onProgressClicked, false );
 		}
 
@@ -1268,7 +1268,7 @@
 		dom.wrapper.removeEventListener( 'touchmove', onTouchMove, false );
 		dom.wrapper.removeEventListener( 'touchend', onTouchEnd, false );
 
-		if ( config.progress && dom.progress ) {
+		if ( config.progress && config.progress !== 'passive' && dom.progress ) {
 			dom.progress.removeEventListener( 'click', onProgressClicked, false );
 		}
 


### PR DESCRIPTION
This extends the progress config option to enable a 'passive' progress bar that prevents mouse clicks from changing slides.