### PR TITLE
fixed unclickable link in slide header

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -176,6 +176,10 @@ body {
 .reveal a {
   position: relative; }
 
+.reveal #header a {
+  z-index: 1;
+}
+
 .reveal .stretch {
   max-width: none;
   max-height: none; }


### PR DESCRIPTION
Links were previously unclickable outside of the slide sections. Made fixes to allow links to be clickable outside of section tag.

Issue #2177