### PR TITLE
Fix .stretch elements on Firefox

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1922,7 +1922,7 @@
 			newHeight = height - element.parentNode.offsetHeight;
 
 			// Restore the old height, just in case
-			element.style.height = oldHeight + 'px';
+			element.style.height = oldHeight;
 
 			// Clear the parent (.slide) height. .removeProperty works in IE9+
 			element.parentNode.style.removeProperty('height');


### PR DESCRIPTION
The oldHeight variable already contains the 'px' suffix,
Firefox doesn't restore it if the suffix is duplicated,
the element's height stays at 0.