### PR TITLE
Use 'background: initial' on img.plain

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -276,6 +276,7 @@ body {
 	.reveal section img.plain {
 		border: 0;
 		box-shadow: none;
+		background: initial;
 	}
 
 	.reveal a img {


### PR DESCRIPTION
This change removes the inherited translucent white background from `.reveal section img.plain`. I think there should be no special background on `.plain` images, as this causes display problem with transparent SVG logos on non-white backgrounds.