### PR TITLE
Only show resume on pause if controls enabled

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -593,8 +593,7 @@
 		dom.speakerNotes.setAttribute( 'tabindex', '0' );
 
 		// Overlay graphic which is displayed during the paused mode
-		dom.pauseOverlay = createSingletonNode( dom.wrapper, 'div', 'pause-overlay', '<button class="resume-button">Resume presentation</button>' );
-		dom.resumeButton = dom.pauseOverlay.querySelector( '.resume-button' );
+		dom.pauseOverlay = createSingletonNode( dom.wrapper, 'div', 'pause-overlay', config.controls ? '<button class="resume-button">Resume presentation</button>' : null );
 
 		dom.wrapper.setAttribute( 'role', 'application' );
 
@@ -1299,7 +1298,7 @@
 			dom.progress.addEventListener( 'click', onProgressClicked, false );
 		}
 
-		dom.resumeButton.addEventListener( 'click', resume, false );
+		dom.pauseOverlay.addEventListener( 'click', resume, false );
 
 		if( config.focusBodyOnPageVisibilityChange ) {
 			var visibilityChange;
@@ -1364,7 +1363,7 @@
 		dom.wrapper.removeEventListener( 'touchmove', onTouchMove, false );
 		dom.wrapper.removeEventListener( 'touchend', onTouchEnd, false );
 
-		dom.resumeButton.removeEventListener( 'click', resume, false );
+		dom.pauseOverlay.removeEventListener( 'click', resume, false );
 
 		if ( config.progress && dom.progress ) {
 			dom.progress.removeEventListener( 'click', onProgressClicked, false );


### PR DESCRIPTION
Hi @hakimel ,

This is such an awesome project! Thank you for making it 👏 

I really love the idea of the pause-mode.
I'm not a big fan of the "Resume presentation"-button though... 🤭

I tried figuring out why it was introduced, but I couldn't.

So in this PR I'm proposing two things:

1. Use `config.controls` to control whether or not the button is shown.
2. Let the entire `dom.pauseOverlay` listen for clicks and close when clicked.

This is just one way you could approach this. You could also introduce a new config for the button, but I thought it made good sense to use the `controls`.

Let me know what you think.