### PR TITLE
bring install instructions to top, as is tradition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ## Table of contents
 
 - [Online Editor](#online-editor)
+- [Installation](#installation)
+  - [Basic setup](#basic-setup)
+  - [Full setup](#full-setup)
+  - [Folder Structure](#folder-structure)
 - [Instructions](#instructions)
   - [Markup](#markup)
   - [Markdown](#markdown)
@@ -48,10 +52,6 @@ reveal.js comes with a broad range of features including [nested slides](https:/
   - [Client presentation](#client-presentation)
   - [Socket.io server](#socketio-server)
 - [MathJax](#mathjax)
-- [Installation](#installation)
-  - [Basic setup](#basic-setup)
-  - [Full setup](#full-setup)
-  - [Folder Structure](#folder-structure)
 - [License](#license)
 
 #### More reading
@@ -65,6 +65,56 @@ reveal.js comes with a broad range of features including [nested slides](https:/
 ## Online Editor
 
 Presentations are written using HTML or Markdown but there's also an online editor for those of you who prefer a graphical interface. Give it a try at [https://slides.com](https://slides.com?ref=github).
+
+
+## Installation
+
+The **basic setup** is for authoring presentations only. The **full setup** gives you access to all reveal.js features and plugins such as speaker notes as well as the development tasks needed to make changes to the source.
+
+### Basic setup
+
+The core of reveal.js is very easy to install. You'll simply need to download a copy of this repository and open the index.html file directly in your browser.
+
+1. Download the latest version of reveal.js from <https://github.com/hakimel/reveal.js/releases>
+2. Unzip and replace the example contents in index.html with your own
+3. Open index.html in a browser to view it
+
+### Full setup
+
+Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code.
+
+1. Install [Node.js](http://nodejs.org/) (4.0.0 or later)
+
+1. Clone the reveal.js repository
+   ```sh
+   $ git clone https://github.com/hakimel/reveal.js.git
+   ```
+
+1. Navigate to the reveal.js folder
+   ```sh
+   $ cd reveal.js
+   ```
+
+1. Install dependencies
+   ```sh
+   $ npm install
+   ```
+
+1. Serve the presentation and monitor source files for changes
+   ```sh
+   $ npm start
+   ```
+
+1. Open <http://localhost:8000> to view your presentation
+
+   You can change the port by using `npm start -- --port=8001`.
+
+### Folder Structure
+
+- **css/** Core styles without which the project does not function
+- **js/** Like above but for JavaScript
+- **plugin/** Components that have been developed as extensions to reveal.js
+- **lib/** All other third party assets (JavaScript, CSS, fonts)
 
 
 ## Instructions
@@ -1250,56 +1300,6 @@ Reveal.initialize({
 ```
 
 Read MathJax's documentation if you need [HTTPS delivery](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn) or serving of [specific versions](http://docs.mathjax.org/en/latest/configuration.html#loading-mathjax-from-the-cdn) for stability.
-
-
-## Installation
-
-The **basic setup** is for authoring presentations only. The **full setup** gives you access to all reveal.js features and plugins such as speaker notes as well as the development tasks needed to make changes to the source.
-
-### Basic setup
-
-The core of reveal.js is very easy to install. You'll simply need to download a copy of this repository and open the index.html file directly in your browser.
-
-1. Download the latest version of reveal.js from <https://github.com/hakimel/reveal.js/releases>
-2. Unzip and replace the example contents in index.html with your own
-3. Open index.html in a browser to view it
-
-### Full setup
-
-Some reveal.js features, like external Markdown and speaker notes, require that presentations run from a local web server. The following instructions will set up such a server as well as all of the development tasks needed to make edits to the reveal.js source code.
-
-1. Install [Node.js](http://nodejs.org/) (4.0.0 or later)
-
-1. Clone the reveal.js repository
-   ```sh
-   $ git clone https://github.com/hakimel/reveal.js.git
-   ```
-
-1. Navigate to the reveal.js folder
-   ```sh
-   $ cd reveal.js
-   ```
-
-1. Install dependencies
-   ```sh
-   $ npm install
-   ```
-
-1. Serve the presentation and monitor source files for changes
-   ```sh
-   $ npm start
-   ```
-
-1. Open <http://localhost:8000> to view your presentation
-
-   You can change the port by using `npm start -- --port=8001`.
-
-### Folder Structure
-
-- **css/** Core styles without which the project does not function
-- **js/** Like above but for JavaScript
-- **plugin/** Components that have been developed as extensions to reveal.js
-- **lib/** All other third party assets (JavaScript, CSS, fonts)
 
 
 ## License


### PR DESCRIPTION
The Install was waaaay at the bottom, which didn't make sense to scroll through all the detailed documentation, just to find how to get started with an install.