### PR TITLE
Decrease specificity of style resets

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -8,19 +8,19 @@
 /*********************************************
  * RESET STYLES
  *********************************************/
-html, body, .reveal div, .reveal span, .reveal applet, .reveal object, .reveal iframe,
-.reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6, .reveal p, .reveal blockquote, .reveal pre,
-.reveal a, .reveal abbr, .reveal acronym, .reveal address, .reveal big, .reveal cite, .reveal code,
-.reveal del, .reveal dfn, .reveal em, .reveal img, .reveal ins, .reveal kbd, .reveal q, .reveal s, .reveal samp,
-.reveal small, .reveal strike, .reveal strong, .reveal sub, .reveal sup, .reveal tt, .reveal var,
-.reveal b, .reveal u, .reveal center,
-.reveal dl, .reveal dt, .reveal dd, .reveal ol, .reveal ul, .reveal li,
-.reveal fieldset, .reveal form, .reveal label, .reveal legend,
-.reveal table, .reveal caption, .reveal tbody, .reveal tfoot, .reveal thead, .reveal tr, .reveal th, .reveal td,
-.reveal article, .reveal aside, .reveal canvas, .reveal details, .reveal embed,
-.reveal figure, .reveal figcaption, .reveal footer, .reveal header, .reveal hgroup,
-.reveal menu, .reveal nav, .reveal output, .reveal ruby, .reveal section, .reveal summary,
-.reveal time, .reveal mark, .reveal audio, .reveal video {
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
   margin: 0;
   padding: 0;
   border: 0;
@@ -28,8 +28,8 @@ html, body, .reveal div, .reveal span, .reveal applet, .reveal object, .reveal i
   font: inherit;
   vertical-align: baseline; }
 
-.reveal article, .reveal aside, .reveal details, .reveal figcaption, .reveal figure,
-.reveal footer, .reveal header, .reveal hgroup, .reveal menu, .reveal nav, .reveal section {
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
   display: block; }
 
 /*********************************************
@@ -62,22 +62,18 @@ body {
   opacity: 1;
   visibility: inherit; }
   .reveal .slides section .fragment.grow.visible {
-    -webkit-transform: scale(1.3);
-            transform: scale(1.3); }
+    transform: scale(1.3); }
 
 .reveal .slides section .fragment.shrink {
   opacity: 1;
   visibility: inherit; }
   .reveal .slides section .fragment.shrink.visible {
-    -webkit-transform: scale(0.7);
-            transform: scale(0.7); }
+    transform: scale(0.7); }
 
 .reveal .slides section .fragment.zoom-in {
-  -webkit-transform: scale(0.1);
-          transform: scale(0.1); }
+  transform: scale(0.1); }
   .reveal .slides section .fragment.zoom-in.visible {
-    -webkit-transform: none;
-            transform: none; }
+    transform: none; }
 
 .reveal .slides section .fragment.fade-out {
   opacity: 1;
@@ -100,32 +96,24 @@ body {
     text-decoration: line-through; }
 
 .reveal .slides section .fragment.fade-up {
-  -webkit-transform: translate(0, 20%);
-          transform: translate(0, 20%); }
+  transform: translate(0, 20%); }
   .reveal .slides section .fragment.fade-up.visible {
-    -webkit-transform: translate(0, 0);
-            transform: translate(0, 0); }
+    transform: translate(0, 0); }
 
 .reveal .slides section .fragment.fade-down {
-  -webkit-transform: translate(0, -20%);
-          transform: translate(0, -20%); }
+  transform: translate(0, -20%); }
   .reveal .slides section .fragment.fade-down.visible {
-    -webkit-transform: translate(0, 0);
-            transform: translate(0, 0); }
+    transform: translate(0, 0); }
 
 .reveal .slides section .fragment.fade-right {
-  -webkit-transform: translate(-20%, 0);
-          transform: translate(-20%, 0); }
+  transform: translate(-20%, 0); }
   .reveal .slides section .fragment.fade-right.visible {
-    -webkit-transform: translate(0, 0);
-            transform: translate(0, 0); }
+    transform: translate(0, 0); }
 
 .reveal .slides section .fragment.fade-left {
-  -webkit-transform: translate(20%, 0);
-          transform: translate(20%, 0); }
+  transform: translate(20%, 0); }
   .reveal .slides section .fragment.fade-left.visible {
-    -webkit-transform: translate(0, 0);
-            transform: translate(0, 0); }
+    transform: translate(0, 0); }
 
 .reveal .slides section .fragment.fade-in-then-out,
 .reveal .slides section .fragment.current-visible {
@@ -200,48 +188,21 @@ body {
 /*********************************************
  * CONTROLS
  *********************************************/
-@-webkit-keyframes bounce-right {
-  0%, 10%, 25%, 40%, 50% {
-    -webkit-transform: translateX(0);
-            transform: translateX(0); }
-  20% {
-    -webkit-transform: translateX(10px);
-            transform: translateX(10px); }
-  30% {
-    -webkit-transform: translateX(-5px);
-            transform: translateX(-5px); } }
 @keyframes bounce-right {
   0%, 10%, 25%, 40%, 50% {
-    -webkit-transform: translateX(0);
-            transform: translateX(0); }
+    transform: translateX(0); }
   20% {
-    -webkit-transform: translateX(10px);
-            transform: translateX(10px); }
+    transform: translateX(10px); }
   30% {
-    -webkit-transform: translateX(-5px);
-            transform: translateX(-5px); } }
-
-@-webkit-keyframes bounce-down {
-  0%, 10%, 25%, 40%, 50% {
-    -webkit-transform: translateY(0);
-            transform: translateY(0); }
-  20% {
-    -webkit-transform: translateY(10px);
-            transform: translateY(10px); }
-  30% {
-    -webkit-transform: translateY(-5px);
-            transform: translateY(-5px); } }
+    transform: translateX(-5px); } }
 
 @keyframes bounce-down {
   0%, 10%, 25%, 40%, 50% {
-    -webkit-transform: translateY(0);
-            transform: translateY(0); }
+    transform: translateY(0); }
   20% {
-    -webkit-transform: translateY(10px);
-            transform: translateY(10px); }
+    transform: translateY(10px); }
   30% {
-    -webkit-transform: translateY(-5px);
-            transform: translateY(-5px); } }
+    transform: translateY(-5px); } }
 
 .reveal .controls {
   display: none;
@@ -262,9 +223,7 @@ body {
     outline: 0;
     cursor: pointer;
     color: currentColor;
-    -webkit-transform: scale(0.9999);
-            transform: scale(0.9999);
-    transition: color 0.2s ease, opacity 0.2s ease, -webkit-transform 0.2s ease;
+    transform: scale(0.9999);
     transition: color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
     z-index: 2;
     pointer-events: auto;
@@ -272,7 +231,7 @@ body {
     visibility: hidden;
     opacity: 0;
     -webkit-appearance: none;
-    -webkit-tap-highlight-color: transparent; }
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
   .reveal .controls .controls-arrow:before,
   .reveal .controls .controls-arrow:after {
     content: '';
@@ -284,66 +243,50 @@ body {
     border-radius: 0.25em;
     background-color: currentColor;
     transition: all 0.15s ease, background-color 0.8s ease;
-    -webkit-transform-origin: 0.2em 50%;
-            transform-origin: 0.2em 50%;
+    transform-origin: 0.2em 50%;
     will-change: transform; }
   .reveal .controls .controls-arrow {
     position: relative;
     width: 3.6em;
     height: 3.6em; }
     .reveal .controls .controls-arrow:before {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(45deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(45deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(45deg); }
     .reveal .controls .controls-arrow:after {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(-45deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(-45deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(-45deg); }
     .reveal .controls .controls-arrow:hover:before {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(40deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(40deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(40deg); }
     .reveal .controls .controls-arrow:hover:after {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(-40deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(-40deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(-40deg); }
     .reveal .controls .controls-arrow:active:before {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(36deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(36deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(36deg); }
     .reveal .controls .controls-arrow:active:after {
-      -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(-36deg);
-              transform: translateX(0.5em) translateY(1.55em) rotate(-36deg); }
+      transform: translateX(0.5em) translateY(1.55em) rotate(-36deg); }
   .reveal .controls .navigate-left {
     right: 6.4em;
     bottom: 3.2em;
-    -webkit-transform: translateX(-10px);
-            transform: translateX(-10px); }
+    transform: translateX(-10px); }
   .reveal .controls .navigate-right {
     right: 0;
     bottom: 3.2em;
-    -webkit-transform: translateX(10px);
-            transform: translateX(10px); }
+    transform: translateX(10px); }
     .reveal .controls .navigate-right .controls-arrow {
-      -webkit-transform: rotate(180deg);
-              transform: rotate(180deg); }
+      transform: rotate(180deg); }
     .reveal .controls .navigate-right.highlight {
-      -webkit-animation: bounce-right 2s 50 both ease-out;
-              animation: bounce-right 2s 50 both ease-out; }
+      animation: bounce-right 2s 50 both ease-out; }
   .reveal .controls .navigate-up {
     right: 3.2em;
     bottom: 6.4em;
-    -webkit-transform: translateY(-10px);
-            transform: translateY(-10px); }
+    transform: translateY(-10px); }
     .reveal .controls .navigate-up .controls-arrow {
-      -webkit-transform: rotate(90deg);
-              transform: rotate(90deg); }
+      transform: rotate(90deg); }
   .reveal .controls .navigate-down {
     right: 3.2em;
     bottom: 0;
-    -webkit-transform: translateY(10px);
-            transform: translateY(10px); }
+    transform: translateY(10px); }
     .reveal .controls .navigate-down .controls-arrow {
-      -webkit-transform: rotate(-90deg);
-              transform: rotate(-90deg); }
+      transform: rotate(-90deg); }
     .reveal .controls .navigate-down.highlight {
-      -webkit-animation: bounce-down 2s 50 both ease-out;
-              animation: bounce-down 2s 50 both ease-out; }
+      animation: bounce-down 2s 50 both ease-out; }
   .reveal .controls[data-controls-back-arrows="faded"] .navigate-left.enabled,
   .reveal .controls[data-controls-back-arrows="faded"] .navigate-up.enabled {
     opacity: 0.3; }
@@ -358,8 +301,7 @@ body {
     visibility: visible;
     opacity: 0.9;
     cursor: pointer;
-    -webkit-transform: none;
-            transform: none; }
+    transform: none; }
   .reveal .controls .enabled.fragmented {
     opacity: 0.5; }
   .reveal .controls .enabled:hover,
@@ -390,13 +332,11 @@ body {
 
 .reveal.no-hover .controls .controls-arrow:hover:before,
 .reveal.no-hover .controls .controls-arrow:active:before {
-  -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(45deg);
-          transform: translateX(0.5em) translateY(1.55em) rotate(45deg); }
+  transform: translateX(0.5em) translateY(1.55em) rotate(45deg); }
 
 .reveal.no-hover .controls .controls-arrow:hover:after,
 .reveal.no-hover .controls .controls-arrow:active:after {
-  -webkit-transform: translateX(0.5em) translateY(1.55em) rotate(-45deg);
-          transform: translateX(0.5em) translateY(1.55em) rotate(-45deg); }
+  transform: translateX(0.5em) translateY(1.55em) rotate(-45deg); }
 
 @media screen and (min-width: 500px) {
   .reveal .controls[data-controls-layout="edges"] {
@@ -506,10 +446,8 @@ body {
   overflow: visible;
   z-index: 1;
   text-align: center;
-  -webkit-perspective: 600px;
-          perspective: 600px;
-  -webkit-perspective-origin: 50% 40%;
-          perspective-origin: 50% 40%; }
+  perspective: 600px;
+  perspective-origin: 50% 40%; }
 
 .reveal .slides > section {
   -ms-perspective: 600px; }
@@ -522,9 +460,7 @@ body {
   padding: 20px 0px;
   pointer-events: auto;
   z-index: 10;
-  -webkit-transform-style: flat;
-          transform-style: flat;
-  transition: -webkit-transform-origin 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), -webkit-transform 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), visibility 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), opacity 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  transform-style: flat;
   transition: transform-origin 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), transform 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), visibility 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985), opacity 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
 
 /* Global transition speed settings */
@@ -588,60 +524,50 @@ body {
  * Aliased 'linear' for backwards compatibility
  *********************************************/
 .reveal.slide section {
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden; }
+  backface-visibility: hidden; }
 
 .reveal .slides > section[data-transition=slide].past,
 .reveal .slides > section[data-transition~=slide-out].past,
 .reveal.slide .slides > section:not([data-transition]).past {
-  -webkit-transform: translate(-150%, 0);
-          transform: translate(-150%, 0); }
+  transform: translate(-150%, 0); }
 
 .reveal .slides > section[data-transition=slide].future,
 .reveal .slides > section[data-transition~=slide-in].future,
 .reveal.slide .slides > section:not([data-transition]).future {
-  -webkit-transform: translate(150%, 0);
-          transform: translate(150%, 0); }
+  transform: translate(150%, 0); }
 
 .reveal .slides > section > section[data-transition=slide].past,
 .reveal .slides > section > section[data-transition~=slide-out].past,
 .reveal.slide .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate(0, -150%);
-          transform: translate(0, -150%); }
+  transform: translate(0, -150%); }
 
 .reveal .slides > section > section[data-transition=slide].future,
 .reveal .slides > section > section[data-transition~=slide-in].future,
 .reveal.slide .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate(0, 150%);
-          transform: translate(0, 150%); }
+  transform: translate(0, 150%); }
 
 .reveal.linear section {
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden; }
+  backface-visibility: hidden; }
 
 .reveal .slides > section[data-transition=linear].past,
 .reveal .slides > section[data-transition~=linear-out].past,
 .reveal.linear .slides > section:not([data-transition]).past {
-  -webkit-transform: translate(-150%, 0);
-          transform: translate(-150%, 0); }
+  transform: translate(-150%, 0); }
 
 .reveal .slides > section[data-transition=linear].future,
 .reveal .slides > section[data-transition~=linear-in].future,
 .reveal.linear .slides > section:not([data-transition]).future {
-  -webkit-transform: translate(150%, 0);
-          transform: translate(150%, 0); }
+  transform: translate(150%, 0); }
 
 .reveal .slides > section > section[data-transition=linear].past,
 .reveal .slides > section > section[data-transition~=linear-out].past,
 .reveal.linear .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate(0, -150%);
-          transform: translate(0, -150%); }
+  transform: translate(0, -150%); }
 
 .reveal .slides > section > section[data-transition=linear].future,
 .reveal .slides > section > section[data-transition~=linear-in].future,
 .reveal.linear .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate(0, 150%);
-          transform: translate(0, 150%); }
+  transform: translate(0, 150%); }
 
 /*********************************************
  * CONVEX TRANSITION
@@ -649,93 +575,78 @@ body {
  *********************************************/
 .reveal .slides section[data-transition=default].stack,
 .reveal.default .slides section.stack {
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d; }
+  transform-style: preserve-3d; }
 
 .reveal .slides > section[data-transition=default].past,
 .reveal .slides > section[data-transition~=default-out].past,
 .reveal.default .slides > section:not([data-transition]).past {
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+  transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
 
 .reveal .slides > section[data-transition=default].future,
 .reveal .slides > section[data-transition~=default-in].future,
 .reveal.default .slides > section:not([data-transition]).future {
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+  transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
 
 .reveal .slides > section > section[data-transition=default].past,
 .reveal .slides > section > section[data-transition~=default-out].past,
 .reveal.default .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
-          transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
+  transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
 
 .reveal .slides > section > section[data-transition=default].future,
 .reveal .slides > section > section[data-transition~=default-in].future,
 .reveal.default .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
-          transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
+  transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
 
 .reveal .slides section[data-transition=convex].stack,
 .reveal.convex .slides section.stack {
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d; }
+  transform-style: preserve-3d; }
 
 .reveal .slides > section[data-transition=convex].past,
 .reveal .slides > section[data-transition~=convex-out].past,
 .reveal.convex .slides > section:not([data-transition]).past {
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+  transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
 
 .reveal .slides > section[data-transition=convex].future,
 .reveal .slides > section[data-transition~=convex-in].future,
 .reveal.convex .slides > section:not([data-transition]).future {
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+  transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
 
 .reveal .slides > section > section[data-transition=convex].past,
 .reveal .slides > section > section[data-transition~=convex-out].past,
 .reveal.convex .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0);
-          transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
+  transform: translate3d(0, -300px, 0) rotateX(70deg) translate3d(0, -300px, 0); }
 
 .reveal .slides > section > section[data-transition=convex].future,
 .reveal .slides > section > section[data-transition~=convex-in].future,
 .reveal.convex .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0);
-          transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
+  transform: translate3d(0, 300px, 0) rotateX(-70deg) translate3d(0, 300px, 0); }
 
 /*********************************************
  * CONCAVE TRANSITION
  *********************************************/
 .reveal .slides section[data-transition=concave].stack,
 .reveal.concave .slides section.stack {
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d; }
+  transform-style: preserve-3d; }
 
 .reveal .slides > section[data-transition=concave].past,
 .reveal .slides > section[data-transition~=concave-out].past,
 .reveal.concave .slides > section:not([data-transition]).past {
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
+  transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
 
 .reveal .slides > section[data-transition=concave].future,
 .reveal .slides > section[data-transition~=concave-in].future,
 .reveal.concave .slides > section:not([data-transition]).future {
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
+  transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
 
 .reveal .slides > section > section[data-transition=concave].past,
 .reveal .slides > section > section[data-transition~=concave-out].past,
 .reveal.concave .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0);
-          transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0); }
+  transform: translate3d(0, -80%, 0) rotateX(-70deg) translate3d(0, -80%, 0); }
 
 .reveal .slides > section > section[data-transition=concave].future,
 .reveal .slides > section > section[data-transition~=concave-in].future,
 .reveal.concave .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0);
-          transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0); }
+  transform: translate3d(0, 80%, 0) rotateX(70deg) translate3d(0, 80%, 0); }
 
 /*********************************************
  * ZOOM TRANSITION
@@ -748,27 +659,23 @@ body {
 .reveal .slides > section[data-transition~=zoom-out].past,
 .reveal.zoom .slides > section:not([data-transition]).past {
   visibility: hidden;
-  -webkit-transform: scale(16);
-          transform: scale(16); }
+  transform: scale(16); }
 
 .reveal .slides > section[data-transition=zoom].future,
 .reveal .slides > section[data-transition~=zoom-in].future,
 .reveal.zoom .slides > section:not([data-transition]).future {
   visibility: hidden;
-  -webkit-transform: scale(0.2);
-          transform: scale(0.2); }
+  transform: scale(0.2); }
 
 .reveal .slides > section > section[data-transition=zoom].past,
 .reveal .slides > section > section[data-transition~=zoom-out].past,
 .reveal.zoom .slides > section > section:not([data-transition]).past {
-  -webkit-transform: translate(0, -150%);
-          transform: translate(0, -150%); }
+  transform: translate(0, -150%); }
 
 .reveal .slides > section > section[data-transition=zoom].future,
 .reveal .slides > section > section[data-transition~=zoom-in].future,
 .reveal.zoom .slides > section > section:not([data-transition]).future {
-  -webkit-transform: translate(0, 150%);
-          transform: translate(0, 150%); }
+  transform: translate(0, 150%); }
 
 /*********************************************
  * CUBE TRANSITION
@@ -778,17 +685,14 @@ body {
  * future version.
  *********************************************/
 .reveal.cube .slides {
-  -webkit-perspective: 1300px;
-          perspective: 1300px; }
+  perspective: 1300px; }
 
 .reveal.cube .slides section {
   padding: 30px;
   min-height: 700px;
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden;
+  backface-visibility: hidden;
   box-sizing: border-box;
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d; }
+  transform-style: preserve-3d; }
 
 .reveal.center.cube .slides section {
   min-height: 0; }
@@ -803,8 +707,7 @@ body {
   top: 0;
   background: rgba(0, 0, 0, 0.1);
   border-radius: 4px;
-  -webkit-transform: translateZ(-20px);
-          transform: translateZ(-20px); }
+  transform: translateZ(-20px); }
 
 .reveal.cube .slides section:not(.stack):after {
   content: '';
@@ -818,36 +721,27 @@ body {
   z-index: 1;
   border-radius: 4px;
   box-shadow: 0px 95px 25px rgba(0, 0, 0, 0.2);
-  -webkit-transform: translateZ(-90px) rotateX(65deg);
-          transform: translateZ(-90px) rotateX(65deg); }
+  transform: translateZ(-90px) rotateX(65deg); }
 
 .reveal.cube .slides > section.stack {
   padding: 0;
   background: none; }
 
 .reveal.cube .slides > section.past {
-  -webkit-transform-origin: 100% 0%;
-          transform-origin: 100% 0%;
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg);
-          transform: translate3d(-100%, 0, 0) rotateY(-90deg); }
+  transform-origin: 100% 0%;
+  transform: translate3d(-100%, 0, 0) rotateY(-90deg); }
 
 .reveal.cube .slides > section.future {
-  -webkit-transform-origin: 0% 0%;
-          transform-origin: 0% 0%;
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg);
-          transform: translate3d(100%, 0, 0) rotateY(90deg); }
+  transform-origin: 0% 0%;
+  transform: translate3d(100%, 0, 0) rotateY(90deg); }
 
 .reveal.cube .slides > section > section.past {
-  -webkit-transform-origin: 0% 100%;
-          transform-origin: 0% 100%;
-  -webkit-transform: translate3d(0, -100%, 0) rotateX(90deg);
-          transform: translate3d(0, -100%, 0) rotateX(90deg); }
+  transform-origin: 0% 100%;
+  transform: translate3d(0, -100%, 0) rotateX(90deg); }
 
 .reveal.cube .slides > section > section.future {
-  -webkit-transform-origin: 0% 0%;
-          transform-origin: 0% 0%;
-  -webkit-transform: translate3d(0, 100%, 0) rotateX(-90deg);
-          transform: translate3d(0, 100%, 0) rotateX(-90deg); }
+  transform-origin: 0% 0%;
+  transform: translate3d(0, 100%, 0) rotateX(-90deg); }
 
 /*********************************************
  * PAGE TRANSITION
@@ -857,17 +751,14 @@ body {
  * future version.
  *********************************************/
 .reveal.page .slides {
-  -webkit-perspective-origin: 0% 50%;
-          perspective-origin: 0% 50%;
-  -webkit-perspective: 3000px;
-          perspective: 3000px; }
+  perspective-origin: 0% 50%;
+  perspective: 3000px; }
 
 .reveal.page .slides section {
   padding: 30px;
   min-height: 700px;
   box-sizing: border-box;
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d; }
+  transform-style: preserve-3d; }
 
 .reveal.page .slides section.past {
   z-index: 12; }
@@ -881,8 +772,7 @@ body {
   left: 0;
   top: 0;
   background: rgba(0, 0, 0, 0.1);
-  -webkit-transform: translateZ(-20px);
-          transform: translateZ(-20px); }
+  transform: translateZ(-20px); }
 
 .reveal.page .slides section:not(.stack):after {
   content: '';
@@ -903,28 +793,20 @@ body {
   background: none; }
 
 .reveal.page .slides > section.past {
-  -webkit-transform-origin: 0% 0%;
-          transform-origin: 0% 0%;
-  -webkit-transform: translate3d(-40%, 0, 0) rotateY(-80deg);
-          transform: translate3d(-40%, 0, 0) rotateY(-80deg); }
+  transform-origin: 0% 0%;
+  transform: translate3d(-40%, 0, 0) rotateY(-80deg); }
 
 .reveal.page .slides > section.future {
-  -webkit-transform-origin: 100% 0%;
-          transform-origin: 100% 0%;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0); }
+  transform-origin: 100% 0%;
+  transform: translate3d(0, 0, 0); }
 
 .reveal.page .slides > section > section.past {
-  -webkit-transform-origin: 0% 0%;
-          transform-origin: 0% 0%;
-  -webkit-transform: translate3d(0, -40%, 0) rotateX(80deg);
-          transform: translate3d(0, -40%, 0) rotateX(80deg); }
+  transform-origin: 0% 0%;
+  transform: translate3d(0, -40%, 0) rotateX(80deg); }
 
 .reveal.page .slides > section > section.future {
-  -webkit-transform-origin: 0% 100%;
-          transform-origin: 0% 100%;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0); }
+  transform-origin: 0% 100%;
+  transform: translate3d(0, 0, 0); }
 
 /*********************************************
  * FADE TRANSITION
@@ -932,8 +814,7 @@ body {
 .reveal .slides section[data-transition=fade],
 .reveal.fade .slides section:not([data-transition]),
 .reveal.fade .slides > section > section:not([data-transition]) {
-  -webkit-transform: none;
-          transform: none;
+  transform: none;
   transition: opacity 0.5s; }
 
 .reveal.fade.overview .slides section,
@@ -945,8 +826,7 @@ body {
  *********************************************/
 .reveal .slides section[data-transition=none],
 .reveal.none .slides section:not([data-transition]) {
-  -webkit-transform: none;
-          transform: none;
+  transform: none;
   transition: none; }
 
 /*********************************************
@@ -1011,8 +891,7 @@ body {
   top: 0;
   left: -50%;
   margin: 70px 0;
-  -webkit-transform: none;
-          transform: none; }
+  transform: none; }
 
 .no-transforms .reveal .slides section section {
   left: 0; }
@@ -1030,8 +909,7 @@ body {
   height: 100%;
   top: 0;
   left: 0;
-  -webkit-perspective: 600px;
-          perspective: 600px; }
+  perspective: 600px; }
 
 .reveal .slide-background {
   display: none;
@@ -1041,7 +919,7 @@ body {
   opacity: 0;
   visibility: hidden;
   overflow: hidden;
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0);
   transition: all 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
 
 .reveal .slide-background-content {
@@ -1089,78 +967,65 @@ body {
 .reveal[data-background-transition=slide] > .backgrounds .slide-background,
 .reveal > .backgrounds .slide-background[data-background-transition=slide] {
   opacity: 1;
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden; }
+  backface-visibility: hidden; }
 
 .reveal[data-background-transition=slide] > .backgrounds .slide-background.past,
 .reveal > .backgrounds .slide-background.past[data-background-transition=slide] {
-  -webkit-transform: translate(-100%, 0);
-          transform: translate(-100%, 0); }
+  transform: translate(-100%, 0); }
 
 .reveal[data-background-transition=slide] > .backgrounds .slide-background.future,
 .reveal > .backgrounds .slide-background.future[data-background-transition=slide] {
-  -webkit-transform: translate(100%, 0);
-          transform: translate(100%, 0); }
+  transform: translate(100%, 0); }
 
 .reveal[data-background-transition=slide] > .backgrounds .slide-background > .slide-background.past,
 .reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=slide] {
-  -webkit-transform: translate(0, -100%);
-          transform: translate(0, -100%); }
+  transform: translate(0, -100%); }
 
 .reveal[data-background-transition=slide] > .backgrounds .slide-background > .slide-background.future,
 .reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=slide] {
-  -webkit-transform: translate(0, 100%);
-          transform: translate(0, 100%); }
+  transform: translate(0, 100%); }
 
 /* Convex */
 .reveal[data-background-transition=convex] > .backgrounds .slide-background.past,
 .reveal > .backgrounds .slide-background.past[data-background-transition=convex] {
   opacity: 0;
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
+  transform: translate3d(-100%, 0, 0) rotateY(-90deg) translate3d(-100%, 0, 0); }
 
 .reveal[data-background-transition=convex] > .backgrounds .slide-background.future,
 .reveal > .backgrounds .slide-background.future[data-background-transition=convex] {
   opacity: 0;
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
+  transform: translate3d(100%, 0, 0) rotateY(90deg) translate3d(100%, 0, 0); }
 
 .reveal[data-background-transition=convex] > .backgrounds .slide-background > .slide-background.past,
 .reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=convex] {
   opacity: 0;
-  -webkit-transform: translate3d(0, -100%, 0) rotateX(90deg) translate3d(0, -100%, 0);
-          transform: translate3d(0, -100%, 0) rotateX(90deg) translate3d(0, -100%, 0); }
+  transform: translate3d(0, -100%, 0) rotateX(90deg) translate3d(0, -100%, 0); }
 
 .reveal[data-background-transition=convex] > .backgrounds .slide-background > .slide-background.future,
 .reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=convex] {
   opacity: 0;
-  -webkit-transform: translate3d(0, 100%, 0) rotateX(-90deg) translate3d(0, 100%, 0);
-          transform: translate3d(0, 100%, 0) rotateX(-90deg) translate3d(0, 100%, 0); }
+  transform: translate3d(0, 100%, 0) rotateX(-90deg) translate3d(0, 100%, 0); }
 
 /* Concave */
 .reveal[data-background-transition=concave] > .backgrounds .slide-background.past,
 .reveal > .backgrounds .slide-background.past[data-background-transition=concave] {
   opacity: 0;
-  -webkit-transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0);
-          transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
+  transform: translate3d(-100%, 0, 0) rotateY(90deg) translate3d(-100%, 0, 0); }
 
 .reveal[data-background-transition=concave] > .backgrounds .slide-background.future,
 .reveal > .backgrounds .slide-background.future[data-background-transition=concave] {
   opacity: 0;
-  -webkit-transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0);
-          transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
+  transform: translate3d(100%, 0, 0) rotateY(-90deg) translate3d(100%, 0, 0); }
 
 .reveal[data-background-transition=concave] > .backgrounds .slide-background > .slide-background.past,
 .reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=concave] {
   opacity: 0;
-  -webkit-transform: translate3d(0, -100%, 0) rotateX(-90deg) translate3d(0, -100%, 0);
-          transform: translate3d(0, -100%, 0) rotateX(-90deg) translate3d(0, -100%, 0); }
+  transform: translate3d(0, -100%, 0) rotateX(-90deg) translate3d(0, -100%, 0); }
 
 .reveal[data-background-transition=concave] > .backgrounds .slide-background > .slide-background.future,
 .reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=concave] {
   opacity: 0;
-  -webkit-transform: translate3d(0, 100%, 0) rotateX(90deg) translate3d(0, 100%, 0);
-          transform: translate3d(0, 100%, 0) rotateX(90deg) translate3d(0, 100%, 0); }
+  transform: translate3d(0, 100%, 0) rotateX(90deg) translate3d(0, 100%, 0); }
 
 /* Zoom */
 .reveal[data-background-transition=zoom] > .backgrounds .slide-background,
@@ -1171,29 +1036,25 @@ body {
 .reveal > .backgrounds .slide-background.past[data-background-transition=zoom] {
   opacity: 0;
   visibility: hidden;
-  -webkit-transform: scale(16);
-          transform: scale(16); }
+  transform: scale(16); }
 
 .reveal[data-background-transition=zoom] > .backgrounds .slide-background.future,
 .reveal > .backgrounds .slide-background.future[data-background-transition=zoom] {
   opacity: 0;
   visibility: hidden;
-  -webkit-transform: scale(0.2);
-          transform: scale(0.2); }
+  transform: scale(0.2); }
 
 .reveal[data-background-transition=zoom] > .backgrounds .slide-background > .slide-background.past,
 .reveal > .backgrounds .slide-background > .slide-background.past[data-background-transition=zoom] {
   opacity: 0;
   visibility: hidden;
-  -webkit-transform: scale(16);
-          transform: scale(16); }
+  transform: scale(16); }
 
 .reveal[data-background-transition=zoom] > .backgrounds .slide-background > .slide-background.future,
 .reveal > .backgrounds .slide-background > .slide-background.future[data-background-transition=zoom] {
   opacity: 0;
   visibility: hidden;
-  -webkit-transform: scale(0.2);
-          transform: scale(0.2); }
+  transform: scale(0.2); }
 
 /* Global transition speed settings */
 .reveal[data-transition-speed="fast"] > .backgrounds .slide-background {
@@ -1206,10 +1067,8 @@ body {
  * OVERVIEW
  *********************************************/
 .reveal.overview {
-  -webkit-perspective-origin: 50% 50%;
-          perspective-origin: 50% 50%;
-  -webkit-perspective: 700px;
-          perspective: 700px; }
+  perspective-origin: 50% 50%;
+  perspective: 700px; }
   .reveal.overview .slides {
     -moz-transform-style: preserve-3d; }
   .reveal.overview .slides section {
@@ -1237,8 +1096,7 @@ body {
     outline: none;
     overflow: visible; }
   .reveal.overview .backgrounds {
-    -webkit-perspective: inherit;
-            perspective: inherit;
+    perspective: inherit;
     -moz-transform-style: preserve-3d; }
   .reveal.overview .backgrounds .slide-background {
     opacity: 1;
@@ -1364,7 +1222,6 @@ body {
 
 .reveal .overlay .viewport {
   position: absolute;
-  display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   top: 40px;
@@ -1405,8 +1262,7 @@ body {
 .reveal .overlay.overlay-preview.loaded .spinner {
   opacity: 0;
   visibility: hidden;
-  -webkit-transform: scale(0.2);
-          transform: scale(0.2); }
+  transform: scale(0.2); }
 
 .reveal .overlay.overlay-help .viewport {
   overflow: auto;
@@ -1448,7 +1304,7 @@ body {
   z-index: 30;
   cursor: pointer;
   transition: all 400ms ease;
-  -webkit-tap-highlight-color: transparent; }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
 
 .reveal.overview .playback {
   opacity: 0;
@@ -1462,10 +1318,8 @@ body {
   line-height: 1.2;
   overflow: hidden;
   vertical-align: top;
-  -webkit-perspective: 400px;
-          perspective: 400px;
-  -webkit-perspective-origin: 50% 50%;
-          perspective-origin: 50% 50%; }
+  perspective: 400px;
+  perspective-origin: 50% 50%; }
 
 .reveal .roll:hover {
   background: none;
@@ -1477,17 +1331,13 @@ body {
   padding: 0 2px;
   pointer-events: none;
   transition: all 400ms ease;
-  -webkit-transform-origin: 50% 0%;
-          transform-origin: 50% 0%;
-  -webkit-transform-style: preserve-3d;
-          transform-style: preserve-3d;
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden; }
+  transform-origin: 50% 0%;
+  transform-style: preserve-3d;
+  backface-visibility: hidden; }
 
 .reveal .roll:hover span {
   background: rgba(0, 0, 0, 0.5);
-  -webkit-transform: translate3d(0px, 0px, -45px) rotateX(90deg);
-          transform: translate3d(0px, 0px, -45px) rotateX(90deg); }
+  transform: translate3d(0px, 0px, -45px) rotateX(90deg); }
 
 .reveal .roll span:after {
   content: attr(data-title);
@@ -1496,12 +1346,9 @@ body {
   left: 0;
   top: 0;
   padding: 0 2px;
-  -webkit-backface-visibility: hidden;
-          backface-visibility: hidden;
-  -webkit-transform-origin: 50% 0%;
-          transform-origin: 50% 0%;
-  -webkit-transform: translate3d(0px, 110%, 0px) rotateX(-90deg);
-          transform: translate3d(0px, 110%, 0px) rotateX(-90deg); }
+  backface-visibility: hidden;
+  transform-origin: 50% 0%;
+  transform: translate3d(0px, 110%, 0px) rotateX(-90deg); }
 
 /*********************************************
  * SPEAKER NOTES
@@ -1577,8 +1424,7 @@ body {
 .zoomed .reveal *,
 .zoomed .reveal *:before,
 .zoomed .reveal *:after {
-  -webkit-backface-visibility: visible !important;
-          backface-visibility: visible !important; }
+  backface-visibility: visible !important; }
 
 .zoomed .reveal .progress,
 .zoomed .reveal .controls {

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -11,19 +11,19 @@
  * RESET STYLES
  *********************************************/
 
-html, body, .reveal div, .reveal span, .reveal applet, .reveal object, .reveal iframe,
-.reveal h1, .reveal h2, .reveal h3, .reveal h4, .reveal h5, .reveal h6, .reveal p, .reveal blockquote, .reveal pre,
-.reveal a, .reveal abbr, .reveal acronym, .reveal address, .reveal big, .reveal cite, .reveal code,
-.reveal del, .reveal dfn, .reveal em, .reveal img, .reveal ins, .reveal kbd, .reveal q, .reveal s, .reveal samp,
-.reveal small, .reveal strike, .reveal strong, .reveal sub, .reveal sup, .reveal tt, .reveal var,
-.reveal b, .reveal u, .reveal center,
-.reveal dl, .reveal dt, .reveal dd, .reveal ol, .reveal ul, .reveal li,
-.reveal fieldset, .reveal form, .reveal label, .reveal legend,
-.reveal table, .reveal caption, .reveal tbody, .reveal tfoot, .reveal thead, .reveal tr, .reveal th, .reveal td,
-.reveal article, .reveal aside, .reveal canvas, .reveal details, .reveal embed,
-.reveal figure, .reveal figcaption, .reveal footer, .reveal header, .reveal hgroup,
-.reveal menu, .reveal nav, .reveal output, .reveal ruby, .reveal section, .reveal summary,
-.reveal time, .reveal mark, .reveal audio, .reveal video {
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
 	margin: 0;
 	padding: 0;
 	border: 0;
@@ -32,8 +32,8 @@ html, body, .reveal div, .reveal span, .reveal applet, .reveal object, .reveal i
 	vertical-align: baseline;
 }
 
-.reveal article, .reveal aside, .reveal details, .reveal figcaption, .reveal figure,
-.reveal footer, .reveal header, .reveal hgroup, .reveal menu, .reveal nav, .reveal section {
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
 	display: block;
 }
 


### PR DESCRIPTION
Leading `.reveal` has been removed from style resets at the top of `reveal.scss`. I hope this PR will be a first step to address the issue #1952.