### PR TITLE
Fix if-statement in readURL

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -4070,10 +4070,13 @@
 			// Ensure that we're not already on a slide with the same name
 			var isSameNameAsCurrentSlide = currentSlide ? currentSlide.getAttribute( 'id' ) === name : false;
 
-			if( element && !isSameNameAsCurrentSlide ) {
-				// Find the position of the named slide and navigate to it
-				var indices = Reveal.getIndices( element );
-				slide( indices.h, indices.v );
+			if( element ) {
+				// If the slide exists and is not the current slide...
+				if ( !isSameNameAsCurrentSlide ) {
+					// ...find the position of the named slide and navigate to it
+					var indices = Reveal.getIndices(element);
+					slide(indices.h, indices.v);
+				}
 			}
 			// If the slide doesn't exist, navigate to the current slide
 			else {


### PR DESCRIPTION
Corrected a nested if statement in readURL() that caused slide(indexh,indexv) to be called even when the current slide equals the target slide pointed to by the read URL.

In the uncorrected version, any slide switch triggers a call to slide(h,v), which calls writeURL(), which triggers readURL(), which then erroneously triggers slide(h,v) a second time.

As a consequence, updateBackground() is called twice (from slide(h,v)) for each slide change. When using background videos the first call starts the video. The second call first stops the video (through stopEmbeddedContent(previousBackground)) and then tries to restarts it again. This unfortunate start-stop-start combination in most cases does not start the background video, but triggers the following error (on Ubuntu 18.04 w/ chromium browser):

"Uncaught (in promise) DOMException: The play() request was interrupted by a call to pause()."

Correcting the if-statement in readURL fixes the issue.