### PR TITLE
Make code font customizable for themes.

### DIFF
--- a/css/theme/template/settings.scss
+++ b/css/theme/template/settings.scss
@@ -28,6 +28,8 @@ $heading2Size: 2.11em;
 $heading3Size: 1.55em;
 $heading4Size: 1.00em;
 
+$codeFont: monospace;
+
 // Links and actions
 $linkColor: #13DAEC;
 $linkColorHover: lighten( $linkColor, 20% );

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -162,7 +162,7 @@ body {
 
 	text-align: left;
 	font-size: 0.55em;
-	font-family: monospace;
+	font-family: $codeFont;
 	line-height: 1.2em;
 
 	word-wrap: break-word;
@@ -171,7 +171,7 @@ body {
 }
 
 .reveal code {
-	font-family: monospace;
+	font-family: $codeFont;
 	text-transform: none;
 }
 


### PR DESCRIPTION
This patch makes it possible to customize the font used for code.
If nothing is specified the old default monospace font is used.