### PR TITLE
Print pagesize fix

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -738,7 +738,7 @@
 				// so that no page ever flows onto another
 				var page = document.createElement( 'div' );
 				page.className = 'pdf-page';
-				page.style.height = ( ( pageHeight + config.pdfPageHeightOffset ) * numberOfPages ) + 'px';
+				page.style.height = ( ( pageHeight + config.pdfPageHeightOffset )  ) + 'px';
 				slide.parentNode.insertBefore( page, slide );
 				page.appendChild( slide );
 


### PR DESCRIPTION
I had an issue where each page was growing to be huge, so the n'th page was n-times larger than the 1st page.  Removing the multiplication by page size fixed the issue for me.  I'm not entirely sure this is a generally correct solution, though, as for some of my presentations, it makes the slides appear in browser all stacked on top of one another.

I believe the issue is related to setting a background-image for the slide.  With a background image included, the multiplication doesn't work, while without a background image, maybe it does?  I'm open to better suggestions on how to fix this issue in general, but I want to at least raise this as an issue with a possible short-term/workaround solution.