### PR TITLE
Fix: Ctrl + click for zoom instead of Alt + click in Demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -93,7 +93,7 @@
 						Press <strong>ESC</strong> to enter the slide overview.
 					</p>
 					<p>
-						Hold down alt and click on any element to zoom in on it using <a href="http://lab.hakim.se/zoom-js">zoom.js</a>. Alt + click anywhere to zoom back out.
+						Hold down <strong>Ctrl</strong> and click on any element to zoom in on it using <a href="http://lab.hakim.se/zoom-js">zoom.js</a>. <strong>Ctrl</strong> + click anywhere to zoom back out.
 					</p>
 				</section>
 


### PR DESCRIPTION
Here is the current demo slide explaining zoom: https://revealjs.com/?transition=slide#/4
For me zoom only works with `Ctrl` + click, instead of `Alt`+ click as explained in the demo.