### PR TITLE
Modularized slides with example.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,0 +1,67 @@
+gulp = require('gulp');
+let replace = require('gulp-replace-task');
+let rename = require('gulp-rename');
+let fs = require("fs");
+
+let mainSlide = "index-modularized.html";
+let buildPath = './build/';
+let sourcePath = './src/';
+
+function buildSlides(fileName, presenters, documentsToReadInOrder) {
+
+	return gulp.src(mainSlide)
+		.pipe(replace({
+			patterns: [
+				{
+					match: 'presenters',
+					replacement: createAnchors(presenters, "&nbsp;and&nbsp;")
+				}
+			]
+		}))
+		.pipe(replace({
+			patterns: [
+				{
+					match: 'slideContents',
+					replacement: loadContentInMemory(documentsToReadInOrder)
+				}
+			]
+		}))
+		.pipe(rename(fileName + ".html"))
+		.pipe(gulp.dest(buildPath));
+};
+
+function loadContentInMemory(documentsToReadInOrder) {
+	let memory = "";
+
+	documentsToReadInOrder.forEach(function (document) {
+		memory += fs.readFileSync(document, "utf8");
+	});
+
+	return memory;
+};
+
+function createAnchors(nameAndLinks, delimiter) {
+	let result = '';
+
+	nameAndLinks.forEach(function (nameAndLink) {
+		var link = '<a href="' + nameAndLink[1] + '">' + nameAndLink[0] + '</\a>';
+
+		if (result != '') {
+			result += delimiter;
+		}
+
+		result += link;
+	});
+
+	return result;
+}
+
+gulp.task('slideDeck', function () {
+	let env = require(sourcePath + 'slideDeck.js');
+
+	let documentsToReadInOrder = env.documentsToReadInOrder;
+	let fileName = env.slidesName;
+	let presenters = env.presenters;
+
+	return buildSlides(fileName, presenters, documentsToReadInOrder);
+});

--- a/content/firstTopic.html
+++ b/content/firstTopic.html
@@ -1,0 +1,3 @@
+<section>
+    <h1>First Topic</h1>
+</section>

--- a/content/secondTopic.html
+++ b/content/secondTopic.html
@@ -1,0 +1,3 @@
+<section>
+    <h1>Second Topic</h1>
+</section>

--- a/index-modularized.html
+++ b/index-modularized.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+		<title>reveal.js</title>
+
+		<link rel="stylesheet" href="css/reset.css">
+		<link rel="stylesheet" href="css/reveal.css">
+		<link rel="stylesheet" href="css/theme/black.css">
+
+		<!-- Theme used for syntax highlighting of code -->
+		<link rel="stylesheet" href="lib/css/zenburn.css">
+
+		<!-- Printing and PDF exports -->
+		<script>
+			var link = document.createElement( 'link' );
+			link.rel = 'stylesheet';
+			link.type = 'text/css';
+			link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+			document.getElementsByTagName( 'head' )[0].appendChild( link );
+		</script>
+	</head>
+	<body>
+		<div class="reveal">
+			<div id="content" class="slides">
+				<section class="title-slide">
+					<h1>Topic</h1>
+					<h5>Summary</h5>
+					<p>
+						<small>Your presenters:<br/>@@presenters</small>
+					</p>
+				</section>
+				@@slideContents
+			</div>
+		</div>
+
+		<script src="js/reveal.js"></script>
+
+		<script>
+			// More info about config & dependencies:
+			// - https://github.com/hakimel/reveal.js#configuration
+			// - https://github.com/hakimel/reveal.js#dependencies
+			Reveal.initialize({
+				dependencies: [
+					{ src: 'plugin/markdown/marked.js' },
+					{ src: 'plugin/markdown/markdown.js' },
+					{ src: 'plugin/notes/notes.js', async: true },
+					{ src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
+				]
+			});
+		</script>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "grunt test",
     "start": "grunt serve",
-    "build": "grunt"
+    "build": "grunt",
+    "buildSlides": "gulp slideDeck"
   },
   "author": {
     "name": "Hakim El Hattab",
@@ -37,7 +38,11 @@
     "grunt-retire": "^1.0.7",
     "grunt-zip": "~0.17.1",
     "mustache": "^2.3.0",
-    "socket.io": "^2.2.0"
+    "socket.io": "^2.2.0",
+    "gulp": "^4.0.0",
+    "gulp-insert": "^0.5.0",
+    "gulp-rename": "^1.4.0",
+    "gulp-replace-task": "^0.11.0"
   },
   "license": "MIT"
 }

--- a/src/presenters.js
+++ b/src/presenters.js
@@ -1,0 +1,5 @@
+let presenters = {};
+
+presenters.a = ['FirstName LastName', ''];
+
+module.exports = presenters;

--- a/src/slideDeck.js
+++ b/src/slideDeck.js
@@ -1,0 +1,17 @@
+let presenters = require('./presenters');
+
+let slideDeck = {};
+
+// name multiple pre defined presenters here to be included in the slide
+slideDeck.presenters = [presenters.a]
+
+//name of the main slide
+slideDeck.slidesName = "slide-deck-modularized";
+
+// content to be included from set of topics
+slideDeck.documentsToReadInOrder = [
+    "content/firstTopic.html",
+    "content/secondTopic.html"
+];
+
+module.exports = slideDeck;


### PR DESCRIPTION
Gulpfile is most probably not the best (didn't know how to do this with grunt)
Executing 'npm buildSlides' will create within build folder a new html file named after the variable in slideDeck.js  