### PR TITLE
allow custom slide numbering functions

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3257,40 +3257,48 @@
 	 *  "h/v":	horizontal / vertical slide number
 	 *    "c":	flattened slide number
 	 *  "c/t":	flattened slide number / total slides
+	 *
+	 * Alternatively, config.slideNumber can be a function returning a
+	 * three-element array with arguments to formatSlideNumber().
 	 */
 	function updateSlideNumber() {
 
 		// Update slide number if enabled
 		if( config.slideNumber && dom.slideNumber ) {
 
-			var value = [];
+			var value;
 			var format = 'h.v';
 
-			// Check if a custom number format is available
-			if( typeof config.slideNumber === 'string' ) {
-				format = config.slideNumber;
-			}
+			if ( typeof config.slideNumber === 'function' ) {
+				value = config.slideNumber();
+			} else {
+				// Check if a custom number format is available
+				if( typeof config.slideNumber === 'string' ) {
+					format = config.slideNumber;
+				}
 
-			// If there are ONLY vertical slides in this deck, always use
-			// a flattened slide number
-			if( !/c/.test( format ) && dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR ).length === 1 ) {
-				format = 'c';
-			}
+				// If there are ONLY vertical slides in this deck, always use
+				// a flattened slide number
+				if( !/c/.test( format ) && dom.wrapper.querySelectorAll( HORIZONTAL_SLIDES_SELECTOR ).length === 1 ) {
+					format = 'c';
+				}
 
-			switch( format ) {
-				case 'c':
-					value.push( getSlidePastCount() + 1 );
-					break;
-				case 'c/t':
-					value.push( getSlidePastCount() + 1, '/', getTotalSlides() );
-					break;
-				case 'h/v':
-					value.push( indexh + 1 );
-					if( isVerticalSlide() ) value.push( '/', indexv + 1 );
-					break;
-				default:
-					value.push( indexh + 1 );
-					if( isVerticalSlide() ) value.push( '.', indexv + 1 );
+				value = [];
+				switch( format ) {
+					case 'c':
+						value.push( getSlidePastCount() + 1 );
+						break;
+					case 'c/t':
+						value.push( getSlidePastCount() + 1, '/', getTotalSlides() );
+						break;
+					case 'h/v':
+						value.push( indexh + 1 );
+						if( isVerticalSlide() ) value.push( '/', indexv + 1 );
+						break;
+					default:
+						value.push( indexh + 1 );
+						if( isVerticalSlide() ) value.push( '.', indexv + 1 );
+				}
 			}
 
 			dom.slideNumber.innerHTML = formatSlideNumber( value[0], value[1], value[2] );


### PR DESCRIPTION
As is, slide numbers can only use one of four hardcoded formats, and there's no way in the API to change them (other than I suppose rewriting the `innerHTML` of the slide numbers box after reveal has rewritten itself in a `slidechanged` signal handler, but that's pretty gross).

For example, I use vertical slides for backup slides, which means that if I'm going through the presentation and don't use them then my slide numbers go `4`, `5.1`, `6`. I'd rather have it go `4`, `5`, `6`, and call the vertical slides below it `5/1`, `5/2`, etc.

This two-line change (most of the diff is indentation...) allows for custom schemes by setting `config.slideNumber`:
```javascript
slideNumber: function() {
    var idx = Reveal.getIndices();
    var value = [idx.h + 1];
    if (idx.v > 0) { // first slide in vertical stacks are just plain
        value.push('/');
        value.push(idx.v);
    }
    return value;
},
```