### PR TITLE
Remove perspective on section

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -490,10 +490,6 @@ body {
   -webkit-perspective-origin: 50% 40%;
           perspective-origin: 50% 40%; }
 
-.reveal .slides > section {
-  -webkit-perspective: 600px;
-          perspective: 600px; }
-
 .reveal .slides > section,
 .reveal .slides > section > section {
   display: none;


### PR DESCRIPTION
If perspective is set at `section` level, the `section` div will act as if `position` is set to `relative`.

As I'm using a lot of reference in slides with following fixed position style, CSS `perspective` attribute is conflicting with it.

``` css
<style>
.bottom {
  position: fixed;
  text-align: center;
  bottom: 32px;
  left: 50%;
  transform: translateX(-50%);
};
</style>
```

If you add `bottom` class to the last paragraph from first slide of `demo.html`, the paragraph is not at the bottom anymore.

``` html
<p class="bottom">
  <small>Created by <a href="http://hakim.se">Hakim El Hattab</a> and <a href="https://github.com/hakimel/reveal.js/graphs/contributors">contributors</a></small>
</p>
```