### PR TITLE
Limit index in updateFragments()

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -4528,6 +4528,11 @@
 					if( currentFragment ) {
 						index = parseInt( currentFragment.getAttribute( 'data-fragment-index' ) || 0, 10 );
 					}
+				} else {
+					var maxIndex = parseInt( fragments[ fragments.length - 1 ].getAttribute( 'data-fragment-index' ), 10 );
+					if ( index > maxIndex ) {
+						index = maxIndex;
+					}
 				}
 
 				toArray( fragments ).forEach( function( el, i ) {


### PR DESCRIPTION
This avoids getting in a state where the fragment index is not -1 but no fragments are marked as current. This can happen when nagivating down from the last fragment at the bottom of a vertical stack of slides or from an outdated URL hash. This is most noticeable with a highlight-current fragment style on the last fragment since it will become unhighlighted.

Presentation showing the issue: https://jsfiddle.net/che1tq6f/1/