### PR TITLE
remove unused `isPrintingPDFFragments` function

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1830,15 +1830,6 @@
 	}
 
 	/**
-	 * Check if this instance is being used to print a PDF with fragments.
-	 */
-	function isPrintingPDFFragments() {
-
-		return ( /print-pdf-fragments/gi ).test( window.location.search );
-
-	}
-
-	/**
 	 * Hides the address bar if we're on a mobile device.
 	 */
 	function hideAddressBar() {


### PR DESCRIPTION
`isPrintingPDFFragments` was in the original PR of #1955, but when you changed it to do per-fragment by default in 3680f1ad10d1cbb4a48eb98673fa7018d1ab36e5 you left this now-unused helper function in. Not used and not in the API, so no reason to keep it. :)