### PR TITLE
add text effects for span grow and shrink fragments

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -76,7 +76,7 @@ body {
     -webkit-transform: scale(0.7);
             transform: scale(0.7); }
 
-.reveal .slides section span.fragment.grow.visible {
+.reveal .slides section span.fragment.shrink.visible {
   font-size: 70%;
 }        
       

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -65,6 +65,10 @@ body {
     -webkit-transform: scale(1.3);
             transform: scale(1.3); }
 
+.reveal .slides section span.fragment.grow.visible {
+  font-size: 130%;
+}         
+
 .reveal .slides section .fragment.shrink {
   opacity: 1;
   visibility: inherit; }
@@ -72,6 +76,10 @@ body {
     -webkit-transform: scale(0.7);
             transform: scale(0.7); }
 
+.reveal .slides section span.fragment.grow.visible {
+  font-size: 70%;
+}        
+      
 .reveal .slides section .fragment.zoom-in {
   -webkit-transform: scale(0.1);
           transform: scale(0.1); }

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -82,6 +82,10 @@ body {
 	}
 }
 
+.reveal .slides section span.fragment.grow.visible {
+  font-size: 130%;
+}
+
 .reveal .slides section .fragment.shrink {
 	opacity: 1;
 	visibility: inherit;
@@ -89,6 +93,10 @@ body {
 	&.visible {
 		transform: scale( 0.7 );
 	}
+}
+
+.reveal .slides section span.fragment.shrink.visible {
+  font-size: 70%;
 }
 
 .reveal .slides section .fragment.zoom-in {


### PR DESCRIPTION
Fixes #2126

Since inline elements don't get transform scale effects, if the grow or shrink fragment class is applied to a span, nothing happens currently. Changing the font-size instead gives the expected result.