### PR TITLE
demo.html - Added Linux instructions for zoom

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -95,6 +95,9 @@
 					<p>
 						Hold down alt and click on any element to zoom in on it using <a href="http://lab.hakim.se/zoom-js">zoom.js</a>. Alt + click anywhere to zoom back out.
 					</p>
+					<p>
+						(NOTE: Use ctrl + click in Linux.)
+					</p>
 				</section>
 
 				<section>


### PR DESCRIPTION
Fixes [issue 2176](https://github.com/hakimel/reveal.js/issues/2176).

In Linux, zoom.js uses ctrl + click, instead of alt + click. This was missing in the relevant slide in the demo at made Linux users think zoom wasn't working. The slide language has been changed and now includes a note mentioning the Linux-specific way to zoom.