### PR TITLE
notes plugin: callRevealApi wants apply, not call

### DIFF
--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -68,7 +68,7 @@ var RevealNotes = (function() {
 		 */
 		function callRevealApi( methodName, methodArguments, callId ) {
 
-			var result = Reveal[methodName].call( Reveal, methodArguments );
+			var result = Reveal[methodName].apply( Reveal, methodArguments );
 			notesPopup.postMessage( JSON.stringify( {
 				namespace: 'reveal-notes',
 				type: 'return',


### PR DESCRIPTION
The `callRevealApi()` function introduced in #2104, which takes `methodArguments` which is clearly supposed to be a list, was passing that list as the first argument to the given function. This didn't really matter, because it's currently only ever called with `[]` and for functions that don't actually take any arguments, but it broke things in my #2337 that introduces an argument to `getSlidesPastCount`.