### PR TITLE
Bugfix: Remove calls to missing modules from gruntfile

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -162,9 +162,6 @@ module.exports = grunt => {
 
 	});
 
-	grunt.loadNpmTasks('grunt-contrib-clean');
-	grunt.loadNpmTasks('grunt-contrib-nodeunit');
-
 	// Default task
 	grunt.registerTask( 'default', [ 'css', 'js' ] );
 


### PR DESCRIPTION
When running the app, Grunt throws the following warnings:
```
>> Local Npm module "grunt-contrib-clean" not found. Is it installed?
>> Local Npm module "grunt-contrib-nodeunit" not found. Is it installed?
```
These packages aren't included in package.json, and the modules don't appear to be used for anything, so I think they can just be removed.