### PR TITLE
Switch to MathJax CommonHTML renderer

### DIFF
--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -336,6 +336,7 @@
 		</div>
 
 		<script src="../../plugin/markdown/marked.js"></script>
+
 		<script>
 
 			(function() {
@@ -388,6 +389,9 @@
 							pendingCalls[data.callId](data.result);
 							delete pendingCalls[data.callId];
 						}
+						else if( data.type === 'mathjax' ) {
+							handleLoadMathJax( data );
+						}
 					}
 					// Messages sent by the reveal.js inside of the current slide preview
 					else if( data && data.namespace === 'reveal' ) {
@@ -435,8 +439,35 @@
 						setupNotes();
 						setupTimer();
 					}
+                }
 
-				}
+                /*
+                 * Loading mathjax is triggered twice. remember this and only
+                 * load it on the first call.
+				 */
+                var mathjaxLoaded=false; 
+
+				/**
+				 * Called when the main window uses MathJax and passes the URL to load it from.
+				 */
+				function handleLoadMathJax( data ) {
+                    if (!mathjaxLoaded)
+                    {
+                        console.log("load mathjax from " + data.mathjax );
+                        var head    = document.querySelector( 'head' );
+                        var script  = document.createElement( 'script' );
+                        script.type = 'text/javascript';
+                        script.src  = data.mathjax;
+                        script.onload = function() 
+                        {
+                            /* No need to typeset, since the pre-typeset equations are
+                             * sent from the main presentation to the speaker preview */
+                            MathJax.Hub.Config({ skipStartupTypeset: true });
+                        };
+                        head.appendChild( script );
+                        mathjaxLoaded = true;
+                    }
+                }
 
 				/**
 				 * Called when the main window sends an updated state.

--- a/plugin/notes/notes.js
+++ b/plugin/notes/notes.js
@@ -127,6 +127,32 @@ var RevealNotes = (function() {
 
 		}
 
+
+		/**
+		 * Send MathJax configuration to speaker view, so that the correct
+         * math fonts are used in the preview and notes window.
+		 */
+        function sendMathJaxConfig()
+        {
+            // if the presentation uses the math plugin...
+            if (Reveal.hasPlugin('math'))
+            {            
+                // ...find the location of the MathJax script
+                var mathjaxScript = document.querySelector('script[src*="MathJax.js"]');
+                if (mathjaxScript)
+                {
+                    // ...and send it to the speaker notes view
+                    var messageData = {
+                        namespace: 'reveal-notes',
+                        type: 'mathjax',
+                        mathjax: mathjaxScript.src
+                    };
+                    notesPopup.postMessage( JSON.stringify( messageData ), '*' );
+                }
+            }
+        }
+
+
 		/**
 		 * Called once we have established a connection to the notes
 		 * window.
@@ -145,6 +171,8 @@ var RevealNotes = (function() {
 			// Post the initial state
 			post();
 
+            // Post information on MathJax URL and config
+            sendMathJaxConfig();
 		}
 
 		connect();


### PR DESCRIPTION
# What

This pull request changes the MathJax renderer from HTML-CSS to CommonHTML in the math.js plugin. It also adjusts the notes plugin accordingly to have correct equations in speaker notes.


# Why

CommonHTML (or CHTML) is the default renderer of MathJax since version 2.6, the current version being 2.7.5. Reveal still uses the "old" HTML-CSS renderer. The rendered equations of the CHTML renderer, however, are more consistent/similar across different browsers, and in some cases even more correct. 

For instance, compare old/new for this equation:
$$\{\overrightarrow{S}\rightarrow\overrightarrow{L},\overleftarrow{S}\rightarrow\overleftarrow{L},\overleftarrow{L}\rightarrow\overleftarrow{L}\overrightarrow{S},\overleftarrow{L}\rightarrow\overleftarrow{S}\overrightarrow{L}\}$$


# How

- Select latest MathJax and CHTML configuration as default
- Disable MathJax' matchFontHeight, since this causes problems (for old and new renderer)
- Disable typesetting on slideChange, since it is no longer required
- When exporting a PDF: Use the new promise mechanism to ensure that math typesetting is finished before emitting the 'ready' signal. Otherwise, complex presentations with complex equations end up having some non-typeset equations in the PDF.
- In the speaker notes plugin, the main presentation send the location of the MathJax script to the speaker notes window, which loads the correct MathJax script and then has the correct math fonts.
- Disable AssistiveMML in MathJax configuration, since this setting erroneously duplicates all equations in speaker notes.

# Fixed Issues

Besides switching to the better (more consistent and more correct) math renderer, this pull request fixes the following open issues:
- 1924: Now works thanks to the new reset.css and the disabled matchFontHeight.
- 2105: This problem was caused by dynamically adjusting font height and by re-typesetting upon slide-change. Both can now safely be disabled.
- 1383: This problem was caused by re-typesetting math content on slide changes in overview mode. Both are disabled now.
- 1726: Disabling AssistiveMML removes duplicated math in notes.
- 2256: Solved by enforcing math is typeset in init() function through promises.

I'm using the CommonHTML renderer for math-heavy teaching for about a year now, and it works like a charm. I think it should be used simply because it has been the default choice of MathJax for quite some time. One particular benefit of the more consistent math typesetting is that manual annotation (using a pimped version of the chalkboard plugin) now match the precise location of math terms across different browsers. Let me know if I should prepare slides demonstrating before/after of the above issues.

Cheers
Mario