### PR TITLE
Fix plugin documentation regarding init-Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ Reveal.addEventListener( 'ready', () => console.log( 'Three seconds later...' ) 
 Reveal.initialize();
 ```
 
+For plugins that are loaded as [dependencies](#dependencies), reveal.js will wait for the fullfillment of their init Promise only for the *non-async* plugins. 
 If the init method does _not_ return a Promise, the plugin is considered ready right away and will not hold up the reveal.js startup sequence.
 
 ### Retrieving Plugins


### PR DESCRIPTION
Mention in the plugin section of README that reveal.js will wait for the Promise of a plugin's init() function only when the plugin is loaded non-async (see initPlugins()).

If a plugin is loaded as an async dependency, the wait-for-Promise mechanism in not applied. Reveal waits for the Promises of the non-sync plugins, then calls start(), which triggers the loading of the async plugins and dispatches 'ready'. This dispatching might happen before the async plugins are loaded and their init functions are done and their Promises are fullfilled.

Not sure that this behavior is intended. But I guess it should be documented. Maybe my take at improving the documentation is not perfect through.

BTW: The init-Promise mechanism is great!

Cheers
Mario