### PR TITLE
Handle lazy-loading of background iframes/videos

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3782,6 +3782,11 @@
 			if( background.hasAttribute( 'data-loaded' ) === false ) {
 				background.setAttribute( 'data-loaded', 'true' );
 
+        // NOTE: updateSlidesVisibility() which triggers the loadSlide() function
+        // is called inside the slide() function but before the currentSlide global variable
+        // has been updated so we need to query the present slide to get the current slide
+        var isCurrentSlide = ( slide === document.querySelector('.slides>.present') );
+
 				var backgroundImage = slide.getAttribute( 'data-background-image' ),
 					backgroundVideo = slide.getAttribute( 'data-background-video' ),
 					backgroundVideoLoop = slide.hasAttribute( 'data-background-video-loop' ),
@@ -3828,10 +3833,7 @@
             // If not on current slide, this video has been lazy loaded.
             // Need to add the data-lazy-loaded attribute so Reveal will handle it
             // with all of its other lazy loaded content
-            // NOTE: updateSlidesVisibility() which triggers the loadSlide() function
-            // is called inside the slide() function but before the currentSlide global variable
-            // is updated so we need to query the present slide to get the current slide
-            if (slide !== document.querySelector('.slides>.present') ) {
+            if ( !isCurrentSlide ) {
               video.setAttribute('data-lazy-loaded', '');
           }
 
@@ -3845,7 +3847,7 @@
           // NOTE: updateSlidesVisibility() which triggers the loadSlide() function
           // is called inside the slide() function but before the currentSlide global variable
           // is updated so we need to query the present slide to get the current slide
-          if ( (slide !== document.querySelector('.slides>.present')) && !shouldPreload( slide ) ) {
+          if ( !isCurrentSlide && !shouldPreload( slide ) ) {
             background.removeAttribute( 'data-loaded' );
             return;
           } 
@@ -3877,7 +3879,7 @@
             // If not on current slide, this iframe has been lazy loaded.
             // Need to add the data-lazy-loaded attribute so Reveal will handle it
             // with all of its other lazy loaded content
-            if (slide !== document.querySelector('.slides>.present')) {
+            if ( !isCurrentSlide ) {
               iframe.setAttribute('data-lazy-loaded', '');
             }
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3906,7 +3906,7 @@
 			background.style.display = 'none';
       // reset the lazy loading attribute  of the background so the lazy loaded
       // content will be loaded again once in viewDistance
-      background.removeAttribute( 'data-loaded' )
+      background.removeAttribute( 'data-loaded' );
       // Reset lazy-loaded media elements with src attributes
       toArray( background.querySelectorAll( 'video[data-lazy-loaded][src], iframe[data-lazy-loaded][src]' ) ).forEach( function( element ) {
         element.setAttribute( 'data-src', element.getAttribute( 'src' ) );

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3825,7 +3825,7 @@
               video.innerHTML += '<source src="'+ source +'">';
             } );
 
-            // If not on current slide, this iframe has been lazy loaded.
+            // If not on current slide, this video has been lazy loaded.
             // Need to add the data-lazy-loaded attribute so Reveal will handle it
             // with all of its other lazy loaded content
             // NOTE: updateSlidesVisibility() which triggers the loadSlide() function

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3835,18 +3835,15 @@
             // with all of its other lazy loaded content
             if ( !isCurrentSlide ) {
               video.setAttribute('data-lazy-loaded', '');
-          }
+            }
 
-          backgroundContent.appendChild( video );
+            backgroundContent.appendChild( video );
 
           }
 				}
 				// Iframes
 				else if( backgroundIframe && options.excludeIframes !== true ) {
           // Only create/update iframe if on current slide or data-preload present
-          // NOTE: updateSlidesVisibility() which triggers the loadSlide() function
-          // is called inside the slide() function but before the currentSlide global variable
-          // is updated so we need to query the present slide to get the current slide
           if ( !isCurrentSlide && !shouldPreload( slide ) ) {
             background.removeAttribute( 'data-loaded' );
             return;
@@ -3876,13 +3873,12 @@
             iframe.style.maxHeight = '100%';
             iframe.style.maxWidth = '100%';
 
-            // If not on current slide, this iframe has been lazy loaded.
-            // Need to add the data-lazy-loaded attribute so Reveal will handle it
-            // with all of its other lazy loaded content
-            if ( !isCurrentSlide ) {
-              iframe.setAttribute('data-lazy-loaded', '');
-            }
-
+            // Add the lazy-loaded tag to ensure that iframe will be
+            // "loaded/unloaded correctly when in/out of viewDistance" if the 
+            // data-preload or "loaded on current slide / unloaded when out
+            // of viewDistance" if no data-preload attribute is present
+            iframe.setAttribute('data-lazy-loaded', '');
+            
             backgroundContent.appendChild( iframe );
 
           }

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3793,11 +3793,11 @@
 				}
 				// Videos
 				else if ( backgroundVideo && !isSpeakerNotes() ) {
-          var video = background.querySelector('video')
-          if ( video ) {
+          var hasVideo = background.querySelector('video');
+          if ( hasVideo ) {
             // The background video has been created already so just update its src attribute
             backgroundVideo.split( ',' ).forEach( function( source ) {
-              video.innerHTML += '<source src="'+ source +'">';
+              hasVideo.innerHTML += '<source src="'+ source +'">';
             } );
           } else {
             // The background video has not been created yet, create it
@@ -3847,12 +3847,12 @@
           // is updated so we need to query the present slide to get the current slide
           if ( (slide !== document.querySelector('.slides>.present')) && !shouldPreload( slide ) ) {
             background.removeAttribute( 'data-loaded' );
-            return
+            return;
           } 
-          var iframe = background.querySelector('iframe')
-          if ( iframe ) {
+          var hasIframe = background.querySelector('iframe');
+          if ( hasIframe ) {
             // The background iframe has been created already so just update its src attribute
-            iframe.setAttribute( 'src', backgroundIframe );
+            hasIframe.setAttribute( 'src', backgroundIframe );
           } else {
             // The background iframe has not been created yet, create it
             var iframe = document.createElement( 'iframe' );


### PR DESCRIPTION
Currently, the background videos/iframes added via the `data-background-[video|iframe]` are lazy loaded correctly the first time when in the `viewDistance` of the current slide (and the `data-preload` attribute has been added for the specific case of the iframes). However, if we get out of the `viewDistance` distance, the background content lazy loaded is not unloaded like what happens for regular lazy loaded content on the main slides. This means that for example an iframe in the background content will still use the browser ressources even though it should have been unloaded.

This PR fixes this problem.
