### PR TITLE
Notes: Introduce alternate pacing timer, based on total presentation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,13 @@ Reveal.initialize({
 	// instead of using the defaultTiming value
 	totalTime: 0,
 
+	// Specify the minimum amount of time you want to allot to
+	// each slide, if using the totalTime calculation method.  If
+	// the automated time allocation causes slide pacing to fall
+	// below this threshold, then you will see an alert in the
+	// speaker notes window
+	minimumTimePerSlide: 0;
+
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ Reveal.initialize({
 	// speaker view
 	defaultTiming: 120,
 
+	// Specify the total time in seconds that is available to
+	// present.  If this is set to a nonzero value, the pacing
+	// timer will work out the time available for each slide,
+	// instead of using the defaultTiming value
+	totalTime: 0,
+
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
 
@@ -1228,7 +1234,7 @@ The speaker notes window will also show:
 - Current wall-clock time
 - (Optionally) a pacing timer which indicates whether the current pace of the presentation is on track for the right timing (shown in green), and if not, whether the presenter should speed up (shown in red) or has the luxury of slowing down (blue).
 
-The pacing timer can be enabled by configuring by the `defaultTiming` parameter in the `Reveal` configuration block, which specifies the number of seconds per slide.  120 can be a reasonable rule of thumb.  Timings can also be given per slide `<section>` by setting the `data-timing` attribute.  Both values are in numbers of seconds.
+The pacing timer can be enabled by configuring the `defaultTiming` parameter in the `Reveal` configuration block, which specifies the number of seconds per slide.  120 can be a reasonable rule of thumb.  Alternatively, you can enable the timer by setting `totalTime`, which sets the total length of your presentation (also in seconds).  If both values are specified, `totalTime` wins and `defaultTiming` is ignored.  Regardless of the baseline timing method, timings can also be given per slide `<section>` by setting the `data-timing` attribute (again, in seconds).
 
 
 ## Server Side Speaker Notes

--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -540,6 +540,7 @@
 					callRevealApi( 'getSlidesAttributes', [], function ( slideAttributes ) {
 						callRevealApi( 'getConfig', [], function ( config ) {
 							var totalTime = config.totalTime;
+							var minTimePerSlide = config.minimumTimePerSlide || 0;
 							var defaultTiming = config.defaultTiming;
 							if ((defaultTiming == null) && (totalTime == null)) {
 								callback(null);
@@ -573,6 +574,11 @@
 								var timePerSlide = Math.round( remainingTime / remainingSlides, 0 )
 								// And now we replace every zero-value timing with that average
 								timings = timings.map( function(x) { return (x==0 ? timePerSlide : x) } );
+							}
+							var slidesUnderMinimum = timings.filter( function(x) { return (x < minTimePerSlide) } ).length
+							if ( slidesUnderMinimum ) {
+								message = "The pacing time for " + slidesUnderMinimum + " slide(s) is under the configured minimum of " + minTimePerSlide + " seconds. Check the data-timing attribute on individual slides, or consider increasing the totalTime or minimumTimePerSlide configuration options (or removing some slides).";
+								alert(message);
 							}
 							callback( timings );
 						} );

--- a/plugin/notes/notes.html
+++ b/plugin/notes/notes.html
@@ -539,12 +539,16 @@
 
 					callRevealApi( 'getSlidesAttributes', [], function ( slideAttributes ) {
 						callRevealApi( 'getConfig', [], function ( config ) {
+							var totalTime = config.totalTime;
 							var defaultTiming = config.defaultTiming;
-							if (defaultTiming == null) {
+							if ((defaultTiming == null) && (totalTime == null)) {
 								callback(null);
 								return;
 							}
-
+							// Setting totalTime overrides defaultTiming
+							if (totalTime) {
+								defaultTiming = 0;
+							}
 							var timings = [];
 							for ( var i in slideAttributes ) {
 								var slide = slideAttributes[ i ];
@@ -559,7 +563,17 @@
 								}
 								timings.push(timing);
 							}
-
+							if ( totalTime ) {
+								// After we've allocated time to individual slides, we summarize it and
+								// subtract it from the total time
+								var remainingTime = totalTime - timings.reduce( function(a, b) { return a + b; }, 0 );
+								// The remaining time is divided by the number of slides that have 0 seconds
+								// allocated at the moment, giving the average time-per-slide on the remaining slides
+								var remainingSlides = (timings.filter( function(x) { return x == 0 }) ).length
+								var timePerSlide = Math.round( remainingTime / remainingSlides, 0 )
+								// And now we replace every zero-value timing with that average
+								timings = timings.map( function(x) { return (x==0 ? timePerSlide : x) } );
+							}
 							callback( timings );
 						} );
 					} );


### PR DESCRIPTION
The current pacing timer, introduced in 715cf0ba11db0f913cfd2edb56a2c66aed57b505 (#1564), operates on the assumption that there is a default amount of time to be allocated to each slide, and that individual slides can deviate from that default by specifying their own `data-timing` attribute.

This patch introduces an alternate pacing method: by specifying the `totalTime` configuration option, the presenter can set the total time available to present. The pacing timer will then continue to allocate the exact pacing time for slides that do have `data-timing` set, as before. However, rather than applying the `defaultTiming` constant to all others, it will

- Add up the time already allocated to slides via `data-timing`;
- subtract that from totalTime;
- divide the difference by the number of slides *without* `data-timing` set;
- apply the thus-calculated average to those slides.

`totalTime` has no default, and if both `defaultTiming` and `totalTime` are set, `totalTime wins`. This preserves backward compatibility: if a presenter has set `defaultTiming` and updates reveal.js, `totalTime` will be `null` and `defaultTiming` is still applied to all slides without a `data-timing` attribute. The presenter can then switch to the automatic calculation, if desired, by setting a value for `totalTime`.
