### PR TITLE
Fix arrow down navigation on touch devices

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -227,7 +227,7 @@ body {
   bottom: 12px;
   right: 12px;
   left: auto;
-  z-index: 1;
+  z-index: 11;
   color: #000;
   pointer-events: none;
   font-size: 10px; }
@@ -312,7 +312,8 @@ body {
               transform: rotate(90deg); }
   .reveal .controls .navigate-down {
     right: 3.2em;
-    bottom: 0;
+    bottom: -1.4em;
+    padding-bottom: 1.4em;
     -webkit-transform: translateY(10px);
             transform: translateY(10px); }
     .reveal .controls .navigate-down .controls-arrow {

--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -263,7 +263,7 @@ $controlsArrowAngleActive: 36deg;
 	bottom: $spacing;
 	right: $spacing;
 	left: auto;
-	z-index: 1;
+	z-index: 11;
 	color: #000;
 	pointer-events: none;
 	font-size: 10px;
@@ -355,7 +355,8 @@ $controlsArrowAngleActive: 36deg;
 
 	.navigate-down {
 		right: $controlArrowSpacing + $controlArrowSize/2;
-		bottom: 0;
+		bottom: -$controlArrowSpacing;
+		padding-bottom: $controlArrowSpacing;
 		transform: translateY( 10px );
 
 		.controls-arrow {


### PR DESCRIPTION
Some users reported me that the arrow down doesn't work on touch devices. They found that the arrow down brings them to the last slide sometimes.

After some investigations, I and @Ir0nsides have realized that it's not a bug per se, it's just a usability problem. There is a (too much) subtle space between the arrows and the progress bar that, on a touch device, make the user tap on the progress bar instead of on the arrow.

What we have done: we augmented the sensible area of the arrow down to avoid this kind of problems. It, obviously, make impossible to jump straight to the last slide when touching the progress bar (if the down arrow is visible), but try the current version on a touch device to realize how much is the current behavior annoying.

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)
I'd like to spread some love for the [Open Source Saturday](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/) meetups, a series of events where the only goal is to contribute to OSS ❤️