### PR TITLE
Allow Reveal to be initialized multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Reveal.initialize({
 	// the automated time allocation causes slide pacing to fall
 	// below this threshold, then you will see an alert in the
 	// speaker notes window
-	minimumTimePerSlide: 0;
+	minimumTimePerSlide: 0,
 
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
@@ -395,7 +395,10 @@ Reveal.initialize({
 	parallaxBackgroundVertical: null,
 
 	// The display mode that will be used to show slides
-	display: 'block'
+	display: 'block',
+
+	// Allow Reveal to be initialized multiple times, e.g. in a Single Page Application
+	allowMultipleInitializations: false
 
 });
 ```

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -280,7 +280,10 @@
 			hideCursorTime: 5000,
 
 			// Script dependencies to load
-			dependencies: []
+			dependencies: [],
+
+			// Allow Reveal to be initialized multiple times, e.g. in a Single Page Application
+			allowMultipleInitializations: false
 
 		},
 
@@ -386,8 +389,8 @@
 	 */
 	function initialize( options ) {
 
-		// Make sure we only initialize once
-		if( initialized === true ) return;
+		// Make sure we only initialize once if not configured otherwise
+		if( initialized === true && !options.allowMultipleInitializations ) return;
 
 		initialized = true;
 


### PR DESCRIPTION
Since https://github.com/hakimel/reveal.js/commit/6bfa48a667fe91bb1de1b680769aeb7260af3a49 there is no way to initialize Reveal multiple times. We have an SPA where there are many slideshows and the Reveal DOM is created and destroyed multiple times without page reload. I added an option that allows to avoid the default behaviour of allowing initialization only once.