### PR TITLE
* SCSS: Pass colors as CSS Variables

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -14,6 +14,9 @@ body {
 	font-size: $mainFontSize;
 	font-weight: normal;
 	color: $mainColor;
+	--font-family: #{$mainFont};
+	--font-size: #{$mainFontSize};
+	--font-weight: normal;
 	--text-color: #{$mainColor};
 	--link-color: #{$linkColor};
 	--background-color: #{$backgroundColor};

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -14,6 +14,9 @@ body {
 	font-size: $mainFontSize;
 	font-weight: normal;
 	color: $mainColor;
+	--text-color: #{$mainColor};
+	--link-color: #{$linkColor};
+	--background-color: #{$backgroundColor};
 }
 
 ::selection {


### PR DESCRIPTION
Note: CSS needs to be compiled when this is released.

This allows presenters to easily use the colors from [CSS custom properties](https://caniuse.com/#feat=css-variables), like so

```html
<section>
<span width="100px" height="200px" style="background-color:var(--link-color); color:var(--background-color);">Odd scheme</span> for contrast!
</section>
```