### PR TITLE
Add option to skip URI encoding for image urls that already are encoded

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3787,11 +3787,16 @@
 					backgroundVideo = slide.getAttribute( 'data-background-video' ),
 					backgroundVideoLoop = slide.hasAttribute( 'data-background-video-loop' ),
 					backgroundVideoMuted = slide.hasAttribute( 'data-background-video-muted' ),
-					backgroundIframe = slide.getAttribute( 'data-background-iframe' );
+					backgroundIframe = slide.getAttribute( 'data-background-iframe' ),
+					backgroundImageSkipEncoding = slide.getAttribute('data-background-image-skip-encoding');
 
 				// Images
 				if( backgroundImage ) {
-					backgroundContent.style.backgroundImage = 'url('+ encodeURI( backgroundImage ) +')';
+					var url = encodeURI(backgroundImage);
+					if(backgroundImageSkipEncoding){
+						url = backgroundImage;
+					} 
+					backgroundContent.style.backgroundImage = 'url('+ url +')';
 				}
 				// Videos
 				else if ( backgroundVideo && !isSpeakerNotes() ) {


### PR DESCRIPTION
Using urls from firebase storage that already come encoded. The URIEncode call is messing up the urls and the images will not show.

This adds an option `data-background-image-skip-encoding` that can be used in this scenario to avoid re-encoding a url that does not need it.