### PR TITLE
add missing comma to MathJax example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1455,7 +1455,7 @@ Reveal.initialize({
 
 	math: {
 		mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
-		config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
+		config: 'TeX-AMS_HTML-full', // See http://docs.mathjax.org/en/latest/config-files.html
 		// pass other options into `MathJax.Hub.Config()`
 		TeX: { Macros: macros }
 	},


### PR DESCRIPTION
I found that the example configuration of MathJax didn't follow syntax, and so fixed.
I hope this help.
