### PR TITLE
set history to true by default to improve developer experience.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -162,9 +162,6 @@ module.exports = grunt => {
 
 	});
 
-	grunt.loadNpmTasks('grunt-contrib-clean');
-	grunt.loadNpmTasks('grunt-contrib-nodeunit');
-
 	// Default task
 	grunt.registerTask( 'default', [ 'css', 'js' ] );
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 			// - https://github.com/hakimel/reveal.js#configuration
 			// - https://github.com/hakimel/reveal.js#dependencies
 			Reveal.initialize({
+				history: true,
 				dependencies: [
 					{ src: 'plugin/markdown/marked.js' },
 					{ src: 'plugin/markdown/markdown.js' },


### PR DESCRIPTION
It took a while to understand why I had to start from the beginning for every change. Searching for that is not easy either.

See issue #2175

`
While I am developing a presentation, I would like to stay on the current working slide. But after saving changes page is reloaded and presentation is moved to the first slide. It is very annoying. Is there any way to force reveal.js to stay on the current working slide during development? Thanks.
`

possible improvement: add a npm command such as `npm dev` which will automatically set history to true without writing it inside the reveal.js Init function. 