### PR TITLE
Allowing autoplay in data-background-iframe for audio and video elements

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -3855,6 +3855,7 @@
 					iframe.setAttribute( 'allowfullscreen', '' );
 					iframe.setAttribute( 'mozallowfullscreen', '' );
 					iframe.setAttribute( 'webkitallowfullscreen', '' );
+					iframe.setAttribute( 'allow', 'autoplay' );
 
 					iframe.setAttribute( 'data-src', backgroundIframe );
 


### PR DESCRIPTION
It was restricted by «Autoplay Policy Changes»: https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#iframe