### PR TITLE
Add mobileViewDistance config key

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -270,6 +270,10 @@
 			// Number of slides away from the current that are visible
 			viewDistance: 3,
 
+			// Number of slides away from the current that are visible on mobile devices
+			// It is advisable to set this to a lower number than viewDistance in order to save resources
+			mobileViewDistance: 2,
+
 			// The display mode that will be used to show slides
 			display: 'block',
 
@@ -3257,7 +3261,7 @@
 
 			// Limit view distance on weaker devices
 			if( isMobileDevice ) {
-				viewDistance = isOverview() ? 6 : 2;
+				viewDistance = isOverview() ? 6 : config.mobileViewDistance;
 			}
 
 			// All slides need to be visible when exporting to PDF


### PR DESCRIPTION
We use Reveal.js in a project where we only ever want to show 1 slide at a time, so we set `viewDistance: 1`. On mobile devices however, this setting is overriden to `viewDistance: 2` which breaks our application.
This PR adds a `mobileViewDistance` key which defaults to 2, as it was before, but can now be configured at will.