### PR TITLE
Allow slides to be uncounted

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -4206,8 +4206,11 @@
 				if( verticalSlides[j].classList.contains( 'present' ) ) {
 					break mainLoop;
 				}
-
-				pastCount++;
+        // don't count slides with the "uncounted" class attribute
+        if( verticalSlides[j].classList.contains( 'uncounted' ) ){
+          continue;
+        }
+        pastCount++;
 
 			}
 
@@ -4216,10 +4219,12 @@
 				break;
 			}
 
-			// Don't count the wrapping section for vertical slides
-			if( horizontalSlide.classList.contains( 'stack' ) === false ) {
-				pastCount++;
-			}
+      // Don't count the wrapping section for vertical slides and slides marked as
+      // uncounted
+      if( horizontalSlide.classList.contains( 'stack' ) === false &&
+          horizontalSlide.classList.contains( 'uncounted' ) === false ) {
+        pastCount++;
+      }
 
 		}
 
@@ -4429,7 +4434,7 @@
 	 */
 	function getSlides() {
 
-		return toArray( dom.wrapper.querySelectorAll( SLIDES_SELECTOR + ':not(.stack)' ));
+		return toArray( dom.wrapper.querySelectorAll( SLIDES_SELECTOR + ':not(.stack):not(.uncounted)' ));
 
 	}
 


### PR DESCRIPTION
Sometimes it is useful to mark slides as uncounted, e.g. if one wishes to add backup/appendix slides but want's the progress bar to reflect the progress of "non-appendix" slides (c.f. https://github.com/hakimel/reveal.js/issues/1341). This PR adds the possibility of marking a slide with class `.uncounted` to achieve this. Currently people seem to use hacks like https://github.com/hakimel/reveal.js/issues/1341#issuecomment-237025757 which has other side affects and only works for horizontal slides.