### PR TITLE
API: Expose getComputedSlideSize so plugin developers can get width and height.

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,8 @@ Reveal.getConfig();
 // Fetch the current scale of the presentation
 Reveal.getScale();
 
+Reveal.getComputedSlideSize(); // Returns object with width, height keys, and (scaled) presentationWidth and presentationHeight.
+
 // Retrieves the previous and current slide elements
 Reveal.getPreviousSlide();
 Reveal.getCurrentSlide();

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -6206,6 +6206,7 @@
 		getScale: function() {
 			return scale;
 		},
+		getComputedSlideSize: getComputedSlideSize,
 
 		// Returns the current configuration object
 		getConfig: function() {


### PR DESCRIPTION
Closes https://github.com/hakimel/reveal.js/issues/2409

Plugin developers can use `Reveal.getComputedSlideSize.width` and `Reveal.getComputedSlideSize.height` to get the width and height.