### PR TITLE
fix typo in configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Reveal.initialize({
 	// the automated time allocation causes slide pacing to fall
 	// below this threshold, then you will see an alert in the
 	// speaker notes window
-	minimumTimePerSlide: 0;
+	minimumTimePerSlide: 0,
 
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,


### PR DESCRIPTION
Fixes a syntax error in the README.md example configuration