### PR TITLE
Fixing un-clickable links in print pdf mode

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [hakimel]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# reveal.js [![Build Status](https://travis-ci.org/hakimel/reveal.js.svg?branch=master)](https://travis-ci.org/hakimel/reveal.js) <a href="https://slides.com?ref=github"><img src="https://s3.amazonaws.com/static.slid.es/images/slides-github-banner-320x40.png?1" alt="Slides" width="160" height="20"></a>
+# reveal.js ![tests](https://github.com/hakimel/reveal.js/workflows/tests/badge.svg) <a href="https://slides.com?ref=github"><img src="https://s3.amazonaws.com/static.slid.es/images/slides-github-banner-320x40.png?1" alt="Slides" width="160" height="20"></a>
 
 A framework for easily creating beautiful presentations using HTML. [Check out the live demo](https://revealjs.com/).
 

--- a/css/print/pdf.css
+++ b/css/print/pdf.css
@@ -63,6 +63,7 @@ ul, ol, div, p {
 	width: 100% !important;
 	height: auto !important;
 	zoom: 1 !important;
+	pointer-events: initial;
 
 	left: auto;
 	top: auto;


### PR DESCRIPTION
Fixing issue #2583 by re-enabling pointer events while in pdf-print mode