### PR TITLE
Navigation Arrows: Fix visibility bug in linear navigation mode

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -4555,6 +4555,11 @@
 			}
 		}
 
+		if ( horizontalSlides.length > 1 && config.navigationMode === 'linear' ) {
+			routes.right = routes.right || routes.down;
+			routes.left = routes.left || routes.up;
+		}
+
 		// Reverse horizontal controls for rtl
 		if( config.rtl ) {
 			var left = routes.left;


### PR DESCRIPTION
Close https://github.com/hakimel/reveal.js/issues/2582

This can be tested with the following diff

```diff
diff --git a/index.html b/index.html
index 571d152..d3c668f 100644
--- a/index.html
+++ b/index.html
@@ -25,8 +25,14 @@
 	<body>
 		<div class="reveal">
 			<div class="slides">
-				<section>Slide 1</section>
-				<section>Slide 2</section>
+				<section>
+					<section>Slide 1</section>
+					<section>Slide 2</section>
+				</section>
+				<section>
+					<section>Slide 3</section>
+					<section>Slide 4</section>
+				</section>
 			</div>
 		</div>

@@ -38,6 +44,7 @@
 			// - https://github.com/hakimel/reveal.js#dependencies
 			Reveal.initialize({
 				hash: true,
+				navigationMode: "linear",
 				dependencies: [
 					{ src: 'plugin/markdown/marked.js' },
 					{ src: 'plugin/markdown/markdown.js' },
```

Note that this **doesn't** break the arrows for vertical-only presentations (as https://github.com/hakimel/reveal.js/pull/2416 did).