### PR TITLE
Make repository available for packagist.org listing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "hakimel/reveal.js",
+  "name": "hakimel/revealjs",
   "description": "A framework for easily creating beautiful presentations using HTML.",
   "homepage": "https://revealjs.com",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+  "name": "hakimel/reveal.js",
+  "description": "A framework for easily creating beautiful presentations using HTML.",
+  "homepage": "https://revealjs.com",
+  "authors": [
+    {
+      "name": "Hakim El Hattab"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/hakimel/reveal.js/issues"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
Currently, the reveal.js package on packagist.org is quite out of date. (v3.6) If packagist.org could pull the package directly from the main repo this would fix that issue.