### PR TITLE
Add link for README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <img src="https://hakim-static.s3.amazonaws.com/reveal-js/logo/v1/reveal-black-text.svg" alt="reveal.js" width="450">
   <br><br>
-  <img src="https://github.com/hakimel/reveal.js/workflows/tests/badge.svg">
-  <img src="https://s3.amazonaws.com/static.slid.es/images/slides-github-banner-320x40.png?1" alt="Slides" width="160" height="20"></a>
+  <a href="https://github.com/hakimel/reveal.js/actions"><img src="https://github.com/hakimel/reveal.js/workflows/tests/badge.svg"></a>
+  <a href="https://slides.com/"><img src="https://s3.amazonaws.com/static.slid.es/images/slides-github-banner-320x40.png?1" alt="Slides" width="160" height="20"></a>
 </p>
 
 reveal.js is an open source HTML presentation framework. It enables anyone with a web browser to create fully featured and beautiful presentations for free. [Check out the live demo](https://revealjs.com/).


### PR DESCRIPTION
Hi!
I found README badge linked badge itself but user move to bring CI
information or slide.com maybe.
I add link for README badge.