### PR TITLE
allow for custom targets for the slide numbers

### DIFF
--- a/js/controllers/slidenumber.js
+++ b/js/controllers/slidenumber.js
@@ -11,9 +11,17 @@ export default class SlideNumber {
 
 	render() {
 
-		this.element = document.createElement( 'div' );
-		this.element.className = 'slide-number';
-		this.Reveal.getRevealElement().appendChild( this.element );
+		// check for a target container
+		const target = document.querySelector( '.slide-number-target' );
+
+		// reuse target container or create a new one
+		if( target ) {
+			this.element = target;
+		} else {
+			this.element = document.createElement( 'div' );
+			this.element.className = 'slide-number';
+			this.Reveal.getRevealElement().appendChild( this.element );	
+		}
 
 	}
 
@@ -25,10 +33,10 @@ export default class SlideNumber {
 		let slideNumberDisplay = 'none';
 		if( config.slideNumber && !this.Reveal.isPrintingPDF() ) {
 			if( config.showSlideNumber === 'all' ) {
-				slideNumberDisplay = 'block';
+				slideNumberDisplay = 'initial';
 			}
 			else if( config.showSlideNumber === 'speaker' && this.Reveal.isSpeakerNotes() ) {
-				slideNumberDisplay = 'block';
+				slideNumberDisplay = 'initial';
 			}
 		}
 
@@ -106,7 +114,7 @@ export default class SlideNumber {
 	formatNumber( a, delimiter, b, url = '#' + this.Reveal.location.getHash() ) {
 
 		if( typeof b === 'number' && !isNaN( b ) ) {
-			return  `<a href="${url}">
+			return	`<a href="${url}">
 					<span class="slide-number-a">${a}</span>
 					<span class="slide-number-delimiter">${delimiter}</span>
 					<span class="slide-number-b">${b}</span>


### PR DESCRIPTION
Currently you can just switch slide numbers on or off. I think it would be a rather nice feature to allow users to place the slide numbers into custom locations.

In particular, I have a header for my slide deck, that should include the current slide number. With the included changes, I can add a place holder (as follows) at the location I want the slide numbers to show up.

```html
<span class="slide-number-target"></span>
```