### PR TITLE
Fix URL to pdf-export documentation

### DIFF
--- a/css/print/pdf.scss
+++ b/css/print/pdf.scss
@@ -2,7 +2,7 @@
  * This stylesheet is used to print reveal.js
  * presentations to PDF.
  *
- * https://revealjs.revealjs.com/pdf-export/
+ * https://revealjs.com/pdf-export/
  */
 
 html.print-pdf {


### PR DESCRIPTION
Hey 👋 

The URL to the pdf-export documentation in the pdf.scss file was incorrect, this small PR fixes it 😄 