### PR TITLE
Start relative paths in CSS with ./

### DIFF
--- a/css/theme/source/beige.scss
+++ b/css/theme/source/beige.scss
@@ -13,7 +13,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 
 

--- a/css/theme/source/black.scss
+++ b/css/theme/source/black.scss
@@ -12,7 +12,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/source-sans-pro/source-sans-pro.css);
+@import url(./fonts/source-sans-pro/source-sans-pro.css);
 
 
 // Override theme settings (see ../template/settings.scss)

--- a/css/theme/source/league.scss
+++ b/css/theme/source/league.scss
@@ -15,7 +15,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 
 // Override theme settings (see ../template/settings.scss)

--- a/css/theme/source/moon.scss
+++ b/css/theme/source/moon.scss
@@ -12,7 +12,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 
 /**

--- a/css/theme/source/solarized.scss
+++ b/css/theme/source/solarized.scss
@@ -12,7 +12,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 
 

--- a/css/theme/source/white.scss
+++ b/css/theme/source/white.scss
@@ -12,7 +12,7 @@
 
 
 // Include theme-specific fonts
-@import url(fonts/source-sans-pro/source-sans-pro.css);
+@import url(./fonts/source-sans-pro/source-sans-pro.css);
 
 
 // Override theme settings (see ../template/settings.scss)

--- a/dist/theme/beige.css
+++ b/dist/theme/beige.css
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2011-2012 Hakim El Hattab, http://hakim.se
  */
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 /*********************************************
  * GLOBAL STYLES

--- a/dist/theme/black.css
+++ b/dist/theme/black.css
@@ -3,7 +3,7 @@
  *
  * By Hakim El Hattab, http://hakim.se
  */
-@import url(fonts/source-sans-pro/source-sans-pro.css);
+@import url(./fonts/source-sans-pro/source-sans-pro.css);
 section.has-light-background, section.has-light-background h1, section.has-light-background h2, section.has-light-background h3, section.has-light-background h4, section.has-light-background h5, section.has-light-background h6 {
   color: #222; }
 

--- a/dist/theme/fonts/league-gothic/league-gothic.css
+++ b/dist/theme/fonts/league-gothic/league-gothic.css
@@ -1,9 +1,9 @@
 @font-face {
     font-family: 'League Gothic';
-    src: url('league-gothic.eot');
-    src: url('league-gothic.eot?#iefix') format('embedded-opentype'),
-         url('league-gothic.woff') format('woff'),
-         url('league-gothic.ttf') format('truetype');
+    src: url('./league-gothic.eot');
+    src: url('./league-gothic.eot?#iefix') format('embedded-opentype'),
+         url('./league-gothic.woff') format('woff'),
+         url('./league-gothic.ttf') format('truetype');
 
     font-weight: normal;
     font-style: normal;

--- a/dist/theme/fonts/source-sans-pro/source-sans-pro.css
+++ b/dist/theme/fonts/source-sans-pro/source-sans-pro.css
@@ -1,39 +1,39 @@
 @font-face {
     font-family: 'Source Sans Pro';
-    src: url('source-sans-pro-regular.eot');
-    src: url('source-sans-pro-regular.eot?#iefix') format('embedded-opentype'),
-         url('source-sans-pro-regular.woff') format('woff'),
-         url('source-sans-pro-regular.ttf') format('truetype');
+    src: url('./source-sans-pro-regular.eot');
+    src: url('./source-sans-pro-regular.eot?#iefix') format('embedded-opentype'),
+         url('./source-sans-pro-regular.woff') format('woff'),
+         url('./source-sans-pro-regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Source Sans Pro';
-    src: url('source-sans-pro-italic.eot');
-    src: url('source-sans-pro-italic.eot?#iefix') format('embedded-opentype'),
-         url('source-sans-pro-italic.woff') format('woff'),
-         url('source-sans-pro-italic.ttf') format('truetype');
+    src: url('./source-sans-pro-italic.eot');
+    src: url('./source-sans-pro-italic.eot?#iefix') format('embedded-opentype'),
+         url('./source-sans-pro-italic.woff') format('woff'),
+         url('./source-sans-pro-italic.ttf') format('truetype');
     font-weight: normal;
     font-style: italic;
 }
 
 @font-face {
     font-family: 'Source Sans Pro';
-    src: url('source-sans-pro-semibold.eot');
-    src: url('source-sans-pro-semibold.eot?#iefix') format('embedded-opentype'),
-         url('source-sans-pro-semibold.woff') format('woff'),
-         url('source-sans-pro-semibold.ttf') format('truetype');
+    src: url('./source-sans-pro-semibold.eot');
+    src: url('./source-sans-pro-semibold.eot?#iefix') format('embedded-opentype'),
+         url('./source-sans-pro-semibold.woff') format('woff'),
+         url('./source-sans-pro-semibold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Source Sans Pro';
-    src: url('source-sans-pro-semibolditalic.eot');
-    src: url('source-sans-pro-semibolditalic.eot?#iefix') format('embedded-opentype'),
-         url('source-sans-pro-semibolditalic.woff') format('woff'),
-         url('source-sans-pro-semibolditalic.ttf') format('truetype');
+    src: url('./source-sans-pro-semibolditalic.eot');
+    src: url('./source-sans-pro-semibolditalic.eot?#iefix') format('embedded-opentype'),
+         url('./source-sans-pro-semibolditalic.woff') format('woff'),
+         url('./source-sans-pro-semibolditalic.ttf') format('truetype');
     font-weight: 600;
     font-style: italic;
 }

--- a/dist/theme/league.css
+++ b/dist/theme/league.css
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2011-2012 Hakim El Hattab, http://hakim.se
  */
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 /*********************************************
  * GLOBAL STYLES

--- a/dist/theme/moon.css
+++ b/dist/theme/moon.css
@@ -2,7 +2,7 @@
  * Solarized Dark theme for reveal.js.
  * Author: Achim Staebler
  */
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 /**
  * Solarized colors by Ethan Schoonover

--- a/dist/theme/solarized.css
+++ b/dist/theme/solarized.css
@@ -2,7 +2,7 @@
  * Solarized Light theme for reveal.js.
  * Author: Achim Staebler
  */
-@import url(fonts/league-gothic/league-gothic.css);
+@import url(./fonts/league-gothic/league-gothic.css);
 @import url(https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic);
 /**
  * Solarized colors by Ethan Schoonover

--- a/dist/theme/white.css
+++ b/dist/theme/white.css
@@ -3,7 +3,7 @@
  *
  * By Hakim El Hattab, http://hakim.se
  */
-@import url(fonts/source-sans-pro/source-sans-pro.css);
+@import url(./fonts/source-sans-pro/source-sans-pro.css);
 section.has-dark-background, section.has-dark-background h1, section.has-dark-background h2, section.has-dark-background h3, section.has-dark-background h4, section.has-dark-background h5, section.has-dark-background h6 {
   color: #fff; }
 


### PR DESCRIPTION
The bundler I'm using happens to not work well with relative paths that don't start with `./`.
Since this will not break anything existing, I've added this prefix in the themes and font CSS files.