### PR TITLE
More reasonable notes separator

### DIFF
--- a/plugin/markdown/plugin.js
+++ b/plugin/markdown/plugin.js
@@ -7,7 +7,7 @@
 import marked from 'marked'
 
 const DEFAULT_SLIDE_SEPARATOR = '^\r?\n---\r?\n$',
-	  DEFAULT_NOTES_SEPARATOR = 'notes?:',
+	  DEFAULT_NOTES_SEPARATOR = '^notes?:',
 	  DEFAULT_ELEMENT_ATTRIBUTES_SEPARATOR = '\\\.element\\\s*?(.+?)$',
 	  DEFAULT_SLIDE_ATTRIBUTES_SEPARATOR = '\\\.slide:\\\s*?(\\\S.+?)$';
 


### PR DESCRIPTION
I think the default notes separator should be starts in first column to avoid inline usages.
That's inconvenient to use an escape character or override it with a custom option.

```markdown
... my notes: "Remember to ...
... my notes&colon; "Remember to ...
```