### PR TITLE
Add ability to use 24-hour clock in speaker view [update]

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -211,6 +211,9 @@ export default {
 	// speaker view
 	defaultTiming: null,
 
+	// use 12-hour clock for current time in speaker view
+	speakerView12HourTimeFormat: true,
+
 	// Enable slide navigation via mouse wheel
 	mouseWheel: false,
 

--- a/plugin/notes/speaker-view.html
+++ b/plugin/notes/speaker-view.html
@@ -689,18 +689,20 @@
 
 					function _updateTimer() {
 
-						var hour12 = Reveal.getConfig().speakerView12HourTimeFormat;
+						callRevealApi( 'getConfig', [], function ( config ) {
+							var hour12 = config.speakerView12HourTimeFormat;
 
-						var diff, hours, minutes, seconds,
-						now = new Date();
+							var diff, hours, minutes, seconds,
+							now = new Date();
 
-						diff = now.getTime() - start.getTime();
+							diff = now.getTime() - start.getTime();
 
-						clockEl.innerHTML = now.toLocaleTimeString( 'en-US', { hour12: hour12, hour: '2-digit', minute:'2-digit' } );
-						_displayTime( hoursEl, minutesEl, secondsEl, diff );
-						if (timings !== null) {
-							_updatePacing(diff);
-						}
+							clockEl.innerHTML = now.toLocaleTimeString( 'en-US', { hour12: hour12, hour: '2-digit', minute:'2-digit' } );
+							_displayTime( hoursEl, minutesEl, secondsEl, diff );
+							if (timings !== null) {
+								_updatePacing(diff);
+							}
+						} );
 
 					}
 

--- a/plugin/notes/speaker-view.html
+++ b/plugin/notes/speaker-view.html
@@ -689,12 +689,14 @@
 
 					function _updateTimer() {
 
+						var hour12 = Reveal.getConfig().speakerView12HourTimeFormat;
+
 						var diff, hours, minutes, seconds,
 						now = new Date();
 
 						diff = now.getTime() - start.getTime();
 
-						clockEl.innerHTML = now.toLocaleTimeString( 'en-US', { hour12: true, hour: '2-digit', minute:'2-digit' } );
+						clockEl.innerHTML = now.toLocaleTimeString( 'en-US', { hour12: hour12, hour: '2-digit', minute:'2-digit' } );
 						_displayTime( hoursEl, minutesEl, secondsEl, diff );
 						if (timings !== null) {
 							_updatePacing(diff);


### PR DESCRIPTION
Pull request #2108 (thanks, @kamilbielawski!) did not apply cleanly anymore, so I ported the changes over to current master. I have also taken into account other changes in the code that happened on master in the meantime.

Merging this pull request fixes #2022 and resolves #2108.

The documentation part is _not_ included anymore, because documentation has moved to https://github.com/reveal/revealjs.com. If you like another pull request for that project, please tell me.