### PR TITLE
Fix target for click on progress bar

### DIFF
--- a/js/controllers/progress.js
+++ b/js/controllers/progress.js
@@ -88,14 +88,16 @@ export default class Progress {
 
 		event.preventDefault();
 
-		let slidesTotal = this.Reveal.getHorizontalSlides().length;
+		let slides = this.Reveal.getSlides();
+		let slidesTotal = slides.length;
 		let slideIndex = Math.floor( ( event.clientX / this.getMaxWidth() ) * slidesTotal );
 
 		if( this.Reveal.getConfig().rtl ) {
 			slideIndex = slidesTotal - slideIndex;
 		}
 
-		this.Reveal.slide( slideIndex );
+		let targetIndices = this.Reveal.getIndices(slides[slideIndex]);
+		this.Reveal.slide( targetIndices.h, targetIndices.v );
 
 	}
 


### PR DESCRIPTION
The progress bar shows how many slides have been passed in total.
However, when clicking on the progress bar, the target slide is
computed among the subset of /horizontal/ slides.  Thus, when the new
slide is displayed, the progress bar has usually changed to a point
that is unrelated to the clicked one, which I find surprising.

With this change, the target slide is computed from the number of
total slides.  Thus, after a click on the progress bar, the resulting
progress is close to the clicked point, which seems more natural to
me.