### PR TITLE
Implement data-markdown-text attribute

### DIFF
--- a/examples/markdown.html
+++ b/examples/markdown.html
@@ -18,6 +18,9 @@
 
 			<div class="slides">
 
+                <!-- Set markdown text directly, slides are separated by newline + three dashes + newline, vertical slides identical but two dashes -->
+                <section data-markdown-text="%23%20Setting%20Markdown%20Text%20Demo%0A%0A---%0A%0A%23%23%20Set%20Text%201.1%0A%0AContent%201.1%0A%0ANote%3A%20This%20will%20only%20appear%20in%20the%20speaker%20notes%20window.%0A%0A--%0A%0A%23%23%20Set%20Text%201.2%0A%0AContent%201.2%0A%0A---%0A%0A%23%23%20Set%20Text%202%0A%0AContent%202.1%0A%0A---%0A%0A%23%23%20Set%20Text%203.1%0A%0AContent%203.1%0A%0A--%0A%0A%23%23%20Set%20Text%203.2%0A%0AContent%203.2%0A%0A--%0A%0A%23%23%20Set%20Text%203.3%0A%0A%21%5BExternal%20Image%5D%28https%3A//s3.amazonaws.com/static.slid.es/logo/v2/slides-symbol-512x512.png%29%0A" data-separator="^\n---\n$" data-separator-vertical="^\n--\n$"></section>
+
                 <!-- Use external markdown resource, separate slides by three newlines; vertical slides by two newlines -->
                 <section data-markdown="markdown.md" data-separator="^\n\n\n" data-separator-vertical="^\n\n"></section>
 

--- a/plugin/markdown/plugin.js
+++ b/plugin/markdown/plugin.js
@@ -74,6 +74,7 @@ const Plugin = () => {
 
 			// disregard attributes that are used for markdown loading/parsing
 			if( /data\-(markdown|separator|vertical|notes)/gi.test( name ) ) continue;
+			if( /data\-markdown\-text/gi.test( name ) ) continue;
 
 			if( value ) {
 				result.push( name + '="' + value + '"' );
@@ -206,9 +207,22 @@ const Plugin = () => {
 
 			var externalPromises = [];
 
-			[].slice.call( scope.querySelectorAll( '[data-markdown]:not([data-markdown-parsed])') ).forEach( function( section, i ) {
+			[].slice.call( scope.querySelectorAll( '[data-markdown-text], [data-markdown]:not([data-markdown-parsed])') ).forEach( function( section, i ) {
 
-				if( section.getAttribute( 'data-markdown' ).length ) {
+				var markdownText = section.getAttribute( 'data-markdown-text' );
+
+				if( markdownText ) {
+
+					// Set markdown text directly
+					section.outerHTML = slidify( unescape(markdownText), {
+						separator: section.getAttribute( 'data-separator' ),
+						verticalSeparator: section.getAttribute( 'data-separator-vertical' ),
+						notesSeparator: section.getAttribute( 'data-separator-notes' ),
+						attributes: getForwardedAttributes( section )
+					});
+
+				}
+				else if( section.getAttribute( 'data-markdown' ).length ) {
 
 					externalPromises.push( loadExternalMarkdown( section ).then(
 


### PR DESCRIPTION
Sometimes it's very useful to set the markdown text directly, instead of loading a file (e.g. via ajax).

This situation happens, for example, when using React components.

This pull-request implements a **data-markdown-text** attribute that receives an **escaped** string representing the markdown text.