### PR TITLE
Implement auto-animate id and restart

### DIFF
--- a/js/controllers/autoanimate.js
+++ b/js/controllers/autoanimate.js
@@ -27,8 +27,16 @@ export default class AutoAnimate {
 		// Clean up after prior animations
 		this.reset();
 
-		// Ensure that both slides are auto-animate targets
-		if( fromSlide.hasAttribute( 'data-auto-animate' ) && toSlide.hasAttribute( 'data-auto-animate' ) ) {
+		let allSlides = this.Reveal.getSlides();
+		let toSlideIndex = allSlides.indexOf( toSlide );
+		let fromSlideIndex = allSlides.indexOf( fromSlide );
+
+		// Ensure that both slides are auto-animate targets with the same data-auto-animate-id value
+		// (including null if absent on both) and that data-auto-animate-restart isn't set on the
+		// physically latter slide (independent of slide direction)
+		if( fromSlide.hasAttribute( 'data-auto-animate' ) && toSlide.hasAttribute( 'data-auto-animate' )
+				&& fromSlide.getAttribute( 'data-auto-animate-id' ) === toSlide.getAttribute( 'data-auto-animate-id' ) 
+				&& !( toSlideIndex > fromSlideIndex ? toSlide : fromSlide ).hasAttribute( 'data-auto-animate-restart' ) ) {
 
 			// Create a new auto-animate sheet
 			this.autoAnimateStyleSheet = this.autoAnimateStyleSheet || createStyleSheet();
@@ -40,8 +48,7 @@ export default class AutoAnimate {
 			toSlide.dataset.autoAnimate = 'pending';
 
 			// Flag the navigation direction, needed for fragment buildup
-			let allSlides = this.Reveal.getSlides();
-			animationOptions.slideDirection = allSlides.indexOf( toSlide ) > allSlides.indexOf( fromSlide ) ? 'forward' : 'backward';
+			animationOptions.slideDirection = toSlideIndex > fromSlideIndex ? 'forward' : 'backward';
 
 			// Inject our auto-animate styles for this transition
 			let css = this.getAutoAnimatableElements( fromSlide, toSlide ).map( elements => {

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1251,7 +1251,10 @@ export default function( revealElement, options ) {
 			// Note 20-03-2020:
 			// This needs to happen before we update slide visibility,
 			// otherwise transitions will still run in Safari.
-			if( previousSlide.hasAttribute( 'data-auto-animate' ) && currentSlide.hasAttribute( 'data-auto-animate' ) ) {
+			if( previousSlide.hasAttribute( 'data-auto-animate' ) && currentSlide.hasAttribute( 'data-auto-animate' )
+					&& previousSlide.getAttribute( 'data-auto-animate-id' ) === currentSlide.getAttribute( 'data-auto-animate-id' )
+					&& !( ( indexh > indexhBefore || indexv > indexvBefore ) ? currentSlide : previousSlide ).hasAttribute( 'data-auto-animate-restart' ) ) {
+
 				autoAnimateTransition = true;
 				dom.slides.classList.add( 'disable-slide-transitions' );
 			}


### PR DESCRIPTION
This PR implements both `data-auto-animate-id` and `data-auto-animate-restart`, allowing for finer control of auto animate.

* When at least one of two successive `data-auto-animate` slides has a `data-auto-animate-id` attribute, both need to have the same attribute value in order for auto animate to trigger
* When a `data-auto-animate` slide has a `data-auto-animate-restart` attribute, auto animate does not trigger on the transition between the previous slide and it, but _does_ trigger on the transition between it and the next slide. `data-auto-animate-restart` always negatively overrides auto animate, even breaking two slides with the same `data-auto-animate-id` apart. Note that "previous" and "next" are meant physically, so "previous" always means a slide to the left or the top of the current one and "next" always means a slide to the right or the bottom instead of "previously shown slide" and "next slide to show" (which might go in any direction, breaking `data-auto-animate-restart` which isn't symmetric)

This design is rather flexible and doesn't introduce a breaking change (apart from new attribute names being used by reveal.js): `auto-animate-id` slide pairs without `data-auto-animate-id` and `data-auto-animate-restart` behave just like before

Why both `data-auto-animate-id` and `data-auto-animate-restart`, wouldn't one be enough?
In theory yes, but I think having both is handy. Only `data-auto-animate-restart` would result in an unreadable hell for any non-trivial presentations with multiple auto-animate groups right next to each other and requires a lot of attention to not accidentally mess up the exact break points. While only having `data-auto-animate-id` would require annotating possibly two dozen slides with a different id when all you want is one simple auto animate break in the middle.

Examples: (Slide pairs with different letters won't auto animate)
```html
<section data-auto-animate>A1</section>
<section data-auto-animate>A2</section>
<section data-auto-animate data-auto-animate-restart>B1</section>
<section data-auto-animate>B2</section>
```

```html
<section data-auto-animate data-auto-animate-id="a">A1</section>
<section data-auto-animate data-auto-animate-id="a">A2</section>
<section data-auto-animate>B1</section>
<section data-auto-animate>B2</section>
<section data-auto-animate data-auto-animate-id="c">C1</section>
<section data-auto-animate data-auto-animate-id="c">C2</section>
```

```html
<section data-auto-animate data-auto-animate-id="a">A1</section>
<section data-auto-animate data-auto-animate-id="a">A2</section>
<section data-auto-animate data-auto-animate-id="b">B1</section>
<section data-auto-animate data-auto-animate-id="b">B2</section>
```

```html
<section data-auto-animate data-auto-animate-id="1">A1</section>
<section data-auto-animate data-auto-animate-id="1">A2</section>
<section>
    <section data-auto-animate data-auto-animate-id="2">Vertical B1</section>
    <section data-auto-animate data-auto-animate-id="2">Vertical B2</section>
    <section data-auto-animate data-auto-animate-id="2" data-auto-animate-restart>Vertical C1</section>
    <section data-auto-animate data-auto-animate-id="2">Vertical C2</section>
</section>
<section data-auto-animate>D1</section>
<section>E1</section>
```