### PR TITLE
Use computed background style if colorToRgb fails (fixes #2635)

### DIFF
--- a/js/controllers/backgrounds.js
+++ b/js/controllers/backgrounds.js
@@ -192,8 +192,8 @@ export default class Backgrounds {
 		// color, no class will be added
 		let contrastColor = data.backgroundColor;
 
-		// If no bg color was found, check the computed background
-		if( !contrastColor ) {
+		// If no bg color was found, or it cannot be converted by colorToRgb, check the computed background
+		if( !contrastColor || !colorToRgb( contrastColor ) ) {
 			let computedBackgroundStyle = window.getComputedStyle( element );
 			if( computedBackgroundStyle && computedBackgroundStyle.backgroundColor ) {
 				contrastColor = computedBackgroundStyle.backgroundColor;


### PR DESCRIPTION
The `has-dark-background` class is not properly added, if a named color (e.g. `black`) is used for the `data-background-color` attribute.

If the attribute is explicitly set, it will be passed to `colorToRgb()` which can only handle explicit rgb notations, not named colors.

As a simple workaround, this PR tries the conversion beforehand, and will use the computed styles if it fails.

Alternatively, one could expand `colorToRgb()` to support named colors, e.g. by querying the browser via a `canvas` (c.f. https://stackoverflow.com/a/47355187 ).