### PR TITLE
Fix: multiple image-urls in data-background-image

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -102,7 +102,13 @@ export default class SlideContent {
 
 				// Images
 				if( backgroundImage ) {
-					backgroundContent.style.backgroundImage = 'url('+ encodeURI( backgroundImage ) +')';
+					let backgroundString = ''
+					backgroundImage.split(',').forEach(background => {
+						backgroundString = backgroundString.concat(
+							'url(' + encodeURI(background.trim()) + '),'
+						);
+					})
+					backgroundContent.style.backgroundImage = backgroundString.substr(0, backgroundString.length - 1);
 				}
 				// Videos
 				else if ( backgroundVideo && !this.Reveal.isSpeakerNotes() ) {

--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -102,12 +102,12 @@ export default class SlideContent {
 
 				// Images
 				if( backgroundImage ) {
-					let backgroundString = ''
+					let backgroundString = '';
 					backgroundImage.split(',').forEach(background => {
 						backgroundString = backgroundString.concat(
 							'url(' + encodeURI(background.trim()) + '),'
 						);
-					})
+					});
 					backgroundContent.style.backgroundImage = backgroundString.substr(0, backgroundString.length - 1);
 				}
 				// Videos


### PR DESCRIPTION
Currently, when using the `data-background-image` attribute, the user can only specify one background image. This is, because if a url is given, the whole string given in `data-background-image` is wrapped into `url()`.

This MR allows to use a comma-separated list, e.g.:

```html
<section data-background-image="image1.png, image2.png"></section>
```

Would be happy to see this merged into `dev`.