### PR TITLE
check embedded video start time

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -356,7 +356,9 @@ export default class SlideContent {
 			isVisible  		= !!closest( event.target, '.present' );
 
 		if( isAttachedToDOM && isVisible ) {
-			event.target.currentTime = 0;
+			const timeRegex = /#t=(\d+)/;
+			const matches = event.target.currentSrc.match(timeRegex);
+			event.target.currentTime = matches && matches.length > 0 ? matches[1] : 0;
 			event.target.play();
 		}
 


### PR DESCRIPTION
To allow for specified start times in embedded videos, modify `startEmbeddedMedia` to check for time syntax. 

ie: 
```
<section data-background-video="https://s3.amazonaws.com/static.slid.es/site/homepage/v1/homepage-video-editor.mp4#t=40" data-background-video-loop data-background-video-muted>
</section>
```
