### PR TITLE
Support transition-speed="slow" with default fade

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -1015,8 +1015,15 @@ $controlsArrowAngleActive: 36deg;
 .reveal.fade .slides section:not([data-transition]),
 .reveal.fade .slides>section>section:not([data-transition]) {
 	transform: none;
-	transition: opacity 0.5s;
+	transition: opacity;
 }
+
+.reveal .slides section[data-transition=fade],
+.reveal.fade .slides section:not([data-transition-speed]),
+.reveal.fade .slides>section>section:not([data-transition-speed]) {
+	transition-duration: 0.5s;
+}
+
 
 
 .reveal.fade.overview .slides section,


### PR DESCRIPTION
If I set my default transition to fade and then use `<section data-transition-speed="slow">` without an explicit `data-transition="fade"`, the speed setting has no effect, because it is picking up the speed from the edited "not" clause.  I *believe* this should fix that problem, though I am not a CSS expert.