### PR TITLE
fix npm start -- --host=0.0.0.0 unuseful

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ const autoprefixer = require('gulp-autoprefixer')
 
 const root = yargs.argv.root || '.'
 const port = yargs.argv.port || 8000
+const host = yargs.argv.host || 'localhost'
 
 const banner = `/*!
 * reveal.js ${pkg.version}
@@ -289,7 +290,8 @@ gulp.task('serve', () => {
     connect.server({
         root: root,
         port: port,
-        host: 'localhost',
+        host: host,
+        //host: '0.0.0.0',
         livereload: true
     })
 


### PR DESCRIPTION
I start the server in my cloud server，but it just can run with localhost, even I use "npm start -- --host=0.0.0.0 --port=8001" ,it does anything.