### PR TITLE
don't override an explicit width or height

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -93,8 +93,12 @@
 .reveal img,
 .reveal video,
 .reveal iframe {
-	max-width: 95%;
-	max-height: 95%;
+	&:not([width]) {
+		max-width: 95%;
+	}
+	&:not([height]) {
+		max-height: 95%;
+	}
 }
 .reveal strong,
 .reveal b {


### PR DESCRIPTION
I placed an image in my slide using `style='position: absolute...'` and explicit `width` and `height` attributes but it didn't show up.  Turns out markdown wrapped it in a `<p>`, whose size was then zero… which then forced the image size to zero.