### PR TITLE
gulp: fixing base path for 'package' task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,7 +278,10 @@ gulp.task('package', gulp.series('default', () =>
         './images/**',
         './plugin/**',
         './**.md'
-    ]).pipe(zip('reveal-js-presentation.zip')).pipe(gulp.dest('./'))
+    ],
+    {
+        base: './'
+    }).pipe(zip('reveal-js-presentation.zip')).pipe(gulp.dest('./'))
 
 ))
 


### PR DESCRIPTION
Without this, the zip created does not contains the working directory structure.