### PR TITLE
RevealMath.MathJax3: Allow the skipHtmlTags option to be overriden

### DIFF
--- a/plugin/math/mathjax3.js
+++ b/plugin/math/mathjax3.js
@@ -56,7 +56,7 @@ export const MathJax3 = () => {
             let revealOptions = deck.getConfig().mathjax3 || {};
             let options = {...defaultOptions, ...revealOptions};
             options.tex = {...defaultOptions.tex, ...revealOptions.tex}
-            options.options = {...options.options, ...defaultOptions.options}
+            options.options = {...defaultOptions.options, ...revealOptions.options}
             options.startup = {...defaultOptions.startup, ...revealOptions.startup}
 
             let url = options.mathjax || 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js';


### PR DESCRIPTION
The previous logic here was backwards, and did not allow the user to override `options` in the mathjax config structure.
This makes it match how the `startup` and `tex` fields are merged.