### PR TITLE
Missing lang attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
The lang attribute does not default to English. It defaults to an unknown, which is an accessibility issue.