### PR TITLE
assign --r-heading5 to r.eveal h5 in scss

### DIFF
--- a/css/theme/template/exposer.scss
+++ b/css/theme/template/exposer.scss
@@ -19,6 +19,7 @@
   --r-heading2-size: #{$heading2Size};
   --r-heading3-size: #{$heading3Size};
   --r-heading4-size: #{$heading4Size};
+  --r-heading5-size: #{$heading5Size};
   --r-code-font: #{$codeFont};
   --r-link-color: #{$linkColor};
   --r-link-color-dark: #{darken($linkColor , 15% )};

--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -64,6 +64,7 @@
 .reveal h2 {font-size: var(--r-heading2-size); }
 .reveal h3 {font-size: var(--r-heading3-size); }
 .reveal h4 {font-size: var(--r-heading4-size); }
+.reveal h5 {font-size: var(--r-heading5-size); }
 
 .reveal h1 {
 	text-shadow: var(--r-heading1-text-shadow);


### PR DESCRIPTION
The size that is defined for --r-heading5-size is not taken into account because it was not set in the templates.

Feel free to close this PR if my change does not make sense.