### PR TITLE
Gulp livereload: include subfolders to watch for changes in html and md

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,7 +278,7 @@ gulp.task('package', gulp.series(() =>
             './lib/**',
             './images/**',
             './plugin/**',
-            './**.md'
+            './**/*.md'
         ],
         { base: './' }
     )
@@ -286,7 +286,7 @@ gulp.task('package', gulp.series(() =>
 
 ))
 
-gulp.task('reload', () => gulp.src(['*.html', '*.md'])
+gulp.task('reload', () => gulp.src(['**/*.html', '**/*.md'])
     .pipe(connect.reload()));
 
 gulp.task('serve', () => {
@@ -298,7 +298,7 @@ gulp.task('serve', () => {
         livereload: true
     })
 
-    gulp.watch(['*.html', '*.md'], gulp.series('reload'))
+    gulp.watch(['**/*.html', '**/*.md'], gulp.series('reload'))
 
     gulp.watch(['js/**'], gulp.series('js', 'reload', 'eslint'))
 


### PR DESCRIPTION
Currently it's only watching for changes to `.html` and `.md` files located in the root of the project. I was frustrated when livereload stopped working for me: turns out it was because I put my content into subfolders.

The new config works for files both in root and in subfolders.