### PR TITLE
Disable backgroundTransition during autoAnimate

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -1093,11 +1093,13 @@ $controlsArrowAngleActive: 36deg;
 
 .reveal .no-transition,
 .reveal .no-transition *,
-.reveal .slides.disable-slide-transitions section {
+.reveal .slides.disable-slide-transitions section,
+.reveal .backgrounds.disable-slide-transitions .slide-background {
 	transition: none !important;
 }
 
-.reveal .slides.disable-slide-transitions section {
+.reveal .slides.disable-slide-transitions section,
+.reveal .backgrounds.disable-slide-transitions .slide-background {
 	transform: none !important;
 }
 

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1311,6 +1311,7 @@ export default function( revealElement, options ) {
 
 				autoAnimateTransition = true;
 				dom.slides.classList.add( 'disable-slide-transitions' );
+				backgrounds.element.classList.add( 'disable-slide-transitions' );
 			}
 
 			transition = 'running';
@@ -1416,6 +1417,7 @@ export default function( revealElement, options ) {
 
 			setTimeout( () => {
 				dom.slides.classList.remove( 'disable-slide-transitions' );
+				backgrounds.element.classList.remove( 'disable-slide-transitions' );
 			}, 0 );
 
 			if( config.autoAnimate ) {


### PR DESCRIPTION
Fixes #3346

The "live demo of desired behaviour" link mentioned in #3346 implements this change.  If there's a cleaner/better way to do it, then of course that would be totally fine too.