### PR TITLE
change binding host from localhost to 0.0.0.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ const autoprefixer = require('gulp-autoprefixer')
 
 const root = yargs.argv.root || '.'
 const port = yargs.argv.port || 8000
-const host = yargs.argv.host || 'localhost'
+const host = yargs.argv.host || '0.0.0.0'
 
 const banner = `/*!
 * reveal.js ${pkg.version}
@@ -197,7 +197,7 @@ gulp.task('qunit', () => {
     let serverConfig = {
         root,
         port: 8009,
-        host: 'localhost',
+        host: '0.0.0.0',
         name: 'test-server'
     }
 


### PR DESCRIPTION
## Problem
The binding host of 'localhost' is an issue when containerizing your final reveal.js app. The presentation will not be accesible from outside the container and thus port mapping from host to container port doesn't return the desired result.
The request returns 'ERR_EMPTY_RESPONSE'

## Steps to reproduce
Try to build a container with your binding host of 'localhost'. 
`docker build -t myreveal:1.0 .`

Example Dockerfile: https://github.com/RapTho/selfIntroductionRevealJS/blob/main/Dockerfile

Run the container:
```
docker run -d \
          --name revealjs \
          -p 8000:8000 \
          --restart unless-stopped \
          myreveal:1.0
```

access the browser at http://localhost:8000

## Solution
Change the binding host from 'localhost' to '0.0.0.0' as proposed in this PR