### PR TITLE
Shorten MAX_REPLACE_STATE_FREQUENCY from 1000 to 300

### DIFF
--- a/js/controllers/location.js
+++ b/js/controllers/location.js
@@ -5,7 +5,7 @@ export default class Location {
 
 	// The minimum number of milliseconds that must pass between
 	// calls to history.replaceState
-	MAX_REPLACE_STATE_FREQUENCY = 1000
+	MAX_REPLACE_STATE_FREQUENCY = 300
 
 	constructor( Reveal ) {
 


### PR DESCRIPTION
`debouncedReplaceState()` was introduced to avoid warnings from Safari: "history.replaceState() more than 100 times per 30 seconds". But 1000ms interval is way too long for that.