### PR TITLE
fix(package.json): upgrade a minor version to handle the last fix published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reveal.js",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "The HTML Presentation Framework",
   "homepage": "https://revealjs.com",
   "subdomain": "revealjs",


### PR DESCRIPTION
This fix doesn't upgrade the package version: https://github.com/hakimel/reveal.js/commit/0b44308754d69d2cf596915b6eb226104718d096

The patch is not released because the package is stuck at version 4.5.0 in the NPM registry.

