### PR TITLE
fixes livereload when using root CLI param

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -298,7 +298,11 @@ gulp.task('serve', () => {
         livereload: true
     })
 
-    gulp.watch(['**/*.html', '**/*.md'], gulp.series('reload'))
+    const slidesRoot = root.endsWith('/') ? root : root + '/'
+    gulp.watch([
+        slidesRoot + '**/*.html', 
+        slidesRoot + '**/*.md',
+    ], gulp.series('reload'))
 
     gulp.watch(['js/**'], gulp.series('js', 'reload', 'eslint'))
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -302,6 +302,7 @@ gulp.task('serve', () => {
     gulp.watch([
         slidesRoot + '**/*.html', 
         slidesRoot + '**/*.md',
+        `!${slidesRoot}**/node_modules/**`, // ignore node_modules
     ], gulp.series('reload'))
 
     gulp.watch(['js/**'], gulp.series('js', 'reload', 'eslint'))


### PR DESCRIPTION
when loading an index.html file outside the reveal folder like this 
```bash
npm start --root=../some/path
```
livereload is broken since gulp only looks inside the reveal folder.

This fix allows to make livereload work again even when using slides in another folder.