### PR TITLE
allow theme subfolders

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,7 +164,7 @@ function compileSass() {
 
     sass.render({
         data: transformedFile.contents.toString(),
-        includePaths: ['css/', 'css/theme/template']
+        file: transformedFile.path,
     }, ( err, result ) => {
         if( err ) {
             console.log( vinylFile.path );
@@ -305,7 +305,7 @@ gulp.task('serve', () => {
     gulp.watch(['plugin/**/plugin.js', 'plugin/**/*.html'], gulp.series('plugins', 'reload'))
 
     gulp.watch([
-        'css/theme/source/*.{sass,scss}',
+        'css/theme/source/**/*.{sass,scss}',
         'css/theme/template/*.{sass,scss}',
     ], gulp.series('css-themes', 'reload'))
 


### PR DESCRIPTION
allows custom themes to import files from subfolders inside the `css/theme/source` folder.

in `css/theme/source/custom-theme.scss` we can now do
```scss
@import `custom-theme/controls`;
@import `custom-theme/headings`;
...
```

This is usefull when creating custom themes with lot of features to split sass rules in different scss files.

Also, passing `file` parameter to `sass.render()` makes `@import` instructions work without the need to specify includePaths (that is a hack sometimes used when working only with the `data` parameter since sass doesn't know where the file is and then cannot do relative imports).

As stated in https://sass-lang.com/documentation/js-api/interfaces/legacystringoptions/#file : 
> _If file and [data](https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions#data) are both passed, file is used as the path of the stylesheet for error reporting, but [data](https://sass-lang.com/documentation/js-api/interfaces/LegacyStringOptions#data) is used as the contents of the stylesheet._

Since sass now knows where each file is, it can do relative `@import` without trouble.