### PR TITLE
fix scss watch tasks broken on syntax error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -167,8 +167,7 @@ function compileSass() {
         file: transformedFile.path,
     }, ( err, result ) => {
         if( err ) {
-            console.log( vinylFile.path );
-            console.log( err.formatted );
+            callback(err);
         }
         else {
             transformedFile.extname = '.css';


### PR DESCRIPTION
when there is a syntax error in a sass file (theme or core) the npm start command used to hang, forcing the user to stop and restart the task to compile again. 

this fix allows to keep the start-task watching/compiling even when there is an error :
- the error is displayed in terminal
- the rest of gulp tasks are not called (no reload in the browser)
- the user can edit the scss files to try a fix without the need to stop/restart the `npm start` command

useful when you're working on a theme and you keep making mistakes in the scss code 😅 