### PR TITLE
speed up livereload

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -286,7 +286,7 @@ gulp.task('package', gulp.series(() =>
 
 ))
 
-gulp.task('reload', () => gulp.src(['**/*.html', '**/*.md'])
+gulp.task('reload', () => gulp.src(['index.html'])
     .pipe(connect.reload()));
 
 gulp.task('serve', () => {
@@ -300,7 +300,7 @@ gulp.task('serve', () => {
 
     const slidesRoot = root.endsWith('/') ? root : root + '/'
     gulp.watch([
-        slidesRoot + '**/*.html', 
+        slidesRoot + '**/*.html',
         slidesRoot + '**/*.md',
         `!${slidesRoot}**/node_modules/**`, // ignore node_modules
     ], gulp.series('reload'))


### PR DESCRIPTION
livereload in latest version is  a lot slower than in previous versions : one has to wait 1-4s when saving html or md file to see the result in the browser.

This PR aims to get back to instant refresh, as it was in previous versions of Reveal (as on 3.6, 3.9, 4.0).

The reason of the drop in performance is this commit : https://github.com/hakimel/reveal.js/commit/8492b82d12735969c07a96b0bfd81860fb30862f#diff-25789e3ba4c2adf4a68996260eb693a441b4a834c38b76167a120f0b51b969f7R289

```js
gulp.task('reload', () => gulp.src(['**/*.html', '**/*.md'])
    .pipe(connect.reload()));
```

By passing `**/*.html` and `**/*.md` it looks like (I'm no gulp expert) we force gulp to crawl recursively every folder in the project, searching for html or md files. And this makes a lot of files even in the base reveal.js project (node_modules is not excluded 😰).

This crawling seems quite useless because this task is not responsible for the watch, all it does is telling the browser to refresh. Still, the `connect.reload()` API needs a stream of files to execute (I tried many ways to launch it without `gulp.src(...)` before with no success). 
Since the src stream is irrelevant, I made `gulp.src` only crawl the original `index.html` file, and everything works fine : when modifying a file, even if it's not the base `index.html` file, the browser refreshes instantly, and shows every modifications made.

Here is an approximative bench on my dev computer (macbook pro M1Pro, RAM 32Go), measuring time from file save, to modification shown in browser (may differ from timing showed in terminal) :
- old config : 1000-3000ms, **thousands** (!!!) of network request fired from the browser (all cancelled) 😱  
- new config : 10-50ms, no additional network requests 🥳 