### PR TITLE
Refactored var to let or const, used strict equality operator

### DIFF
--- a/plugin/markdown/plugin.js
+++ b/plugin/markdown/plugin.js
@@ -38,15 +38,15 @@ const Plugin = () => {
 	function getMarkdownFromSlide( section ) {
 
 		// look for a <script> or <textarea data-template> wrapper
-		var template = section.querySelector( '[data-template]' ) || section.querySelector( 'script' );
+		const template = section.querySelector( '[data-template]' ) || section.querySelector( 'script' );
 
 		// strip leading whitespace so it isn't evaluated as code
-		var text = ( template || section ).textContent;
+		let text = ( template || section ).textContent;
 
 		// restore script end tags
 		text = text.replace( new RegExp( SCRIPT_END_PLACEHOLDER, 'g' ), '</script>' );
 
-		var leadingWs = text.match( /^\n?(\s*)/ )[1].length,
+		const leadingWs = text.match( /^\n?(\s*)/ )[1].length,
 			leadingTabs = text.match( /^\n?(\t*)/ )[1].length;
 
 		if( leadingTabs > 0 ) {
@@ -68,11 +68,11 @@ const Plugin = () => {
 	 */
 	function getForwardedAttributes( section ) {
 
-		var attributes = section.attributes;
-		var result = [];
+		const attributes = section.attributes;
+		const result = [];
 
-		for( var i = 0, len = attributes.length; i < len; i++ ) {
-			var name = attributes[i].name,
+		for( let i = 0, len = attributes.length; i < len; i++ ) {
+			const name = attributes[i].name,
 				value = attributes[i].value;
 
 			// disregard attributes that are used for markdown loading/parsing
@@ -114,7 +114,7 @@ const Plugin = () => {
 
 		options = getSlidifyOptions( options );
 
-		var notesMatch = content.split( new RegExp( options.notesSeparator, 'mgi' ) );
+		const notesMatch = content.split( new RegExp( options.notesSeparator, 'mgi' ) );
 
 		if( notesMatch.length === 2 ) {
 			content = notesMatch[0] + '<aside class="notes">' + marked(notesMatch[1].trim()) + '</aside>';
@@ -136,10 +136,10 @@ const Plugin = () => {
 
 		options = getSlidifyOptions( options );
 
-		var separatorRegex = new RegExp( options.separator + ( options.verticalSeparator ? '|' + options.verticalSeparator : '' ), 'mg' ),
+		const separatorRegex = new RegExp( options.separator + ( options.verticalSeparator ? '|' + options.verticalSeparator : '' ), 'mg' ),
 			horizontalSeparatorRegex = new RegExp( options.separator );
 
-		var matches,
+		let matches,
 			lastIndex = 0,
 			isHorizontal,
 			wasHorizontal = true,
@@ -148,7 +148,7 @@ const Plugin = () => {
 
 		// iterate until all blocks between separators are stacked up
 		while( matches = separatorRegex.exec( markdown ) ) {
-			var notes = null;
+			const notes = null;
 
 			// determine direction (horizontal by default)
 			isHorizontal = horizontalSeparatorRegex.test( matches[0] );
@@ -177,10 +177,10 @@ const Plugin = () => {
 		// add the remaining slide
 		( wasHorizontal ? sectionStack : sectionStack[sectionStack.length-1] ).push( markdown.substring( lastIndex ) );
 
-		var markdownSections = '';
+		let markdownSections = '';
 
 		// flatten the hierarchical stack, and insert <section data-markdown> tags
-		for( var i = 0, len = sectionStack.length; i < len; i++ ) {
+		for( let i = 0, len = sectionStack.length; i < len; i++ ) {
 			// vertical
 			if( sectionStack[i] instanceof Array ) {
 				markdownSections += '<section '+ options.attributes +'>';
@@ -209,7 +209,7 @@ const Plugin = () => {
 
 		return new Promise( function( resolve ) {
 
-			var externalPromises = [];
+			const externalPromises = [];
 
 			[].slice.call( scope.querySelectorAll( 'section[data-markdown]:not([data-markdown-parsed])') ).forEach( function( section, i ) {
 
@@ -262,13 +262,13 @@ const Plugin = () => {
 
 		return new Promise( function( resolve, reject ) {
 
-			var xhr = new XMLHttpRequest(),
+			const xhr = new XMLHttpRequest(),
 				url = section.getAttribute( 'data-markdown' );
 
-			var datacharset = section.getAttribute( 'data-charset' );
+			const datacharset = section.getAttribute( 'data-charset' );
 
 			// see https://developer.mozilla.org/en-US/docs/Web/API/element.getAttribute#Notes
-			if( datacharset != null && datacharset != '' ) {
+			if( datacharset !== null && datacharset !== '' ) {
 				xhr.overrideMimeType( 'text/html; charset=' + datacharset );
 			}
 
@@ -313,14 +313,14 @@ const Plugin = () => {
 	 */
 	function addAttributeInElement( node, elementTarget, separator ) {
 
-		var markdownClassesInElementsRegex = new RegExp( separator, 'mg' );
-		var markdownClassRegex = new RegExp( "([^\"= ]+?)=\"([^\"]+?)\"|(data-[^\"= ]+?)(?=[\" ])", 'mg' );
-		var nodeValue = node.nodeValue;
-		var matches,
+		const markdownClassesInElementsRegex = new RegExp( separator, 'mg' );
+		const markdownClassRegex = new RegExp( "([^\"= ]+?)=\"([^\"]+?)\"|(data-[^\"= ]+?)(?=[\" ])", 'mg' );
+		let nodeValue = node.nodeValue;
+		let matches,
 			matchesClass;
 		if( matches = markdownClassesInElementsRegex.exec( nodeValue ) ) {
 
-			var classes = matches[1];
+			const classes = matches[1];
 			nodeValue = nodeValue.substring( 0, matches.index ) + nodeValue.substring( markdownClassesInElementsRegex.lastIndex );
 			node.nodeValue = nodeValue;
 			while( matchesClass = markdownClassRegex.exec( classes ) ) {
@@ -341,34 +341,34 @@ const Plugin = () => {
 	 */
 	function addAttributes( section, element, previousElement, separatorElementAttributes, separatorSectionAttributes ) {
 
-		if ( element != null && element.childNodes != undefined && element.childNodes.length > 0 ) {
-			var previousParentElement = element;
-			for( var i = 0; i < element.childNodes.length; i++ ) {
-				var childElement = element.childNodes[i];
+		if ( element !== null && element.childNodes !== undefined && element.childNodes.length > 0 ) {
+			let previousParentElement = element;
+			for( let i = 0; i < element.childNodes.length; i++ ) {
+				const childElement = element.childNodes[i];
 				if ( i > 0 ) {
-					var j = i - 1;
+					let j = i - 1;
 					while ( j >= 0 ) {
-						var aPreviousChildElement = element.childNodes[j];
-						if ( typeof aPreviousChildElement.setAttribute == 'function' && aPreviousChildElement.tagName != "BR" ) {
+						const aPreviousChildElement = element.childNodes[j];
+						if ( typeof aPreviousChildElement.setAttribute === 'function' && aPreviousChildElement.tagName !== "BR" ) {
 							previousParentElement = aPreviousChildElement;
 							break;
 						}
 						j = j - 1;
 					}
 				}
-				var parentSection = section;
-				if( childElement.nodeName ==  "section" ) {
+				let parentSection = section;
+				if( childElement.nodeName ===  "section" ) {
 					parentSection = childElement ;
 					previousParentElement = childElement ;
 				}
-				if ( typeof childElement.setAttribute == 'function' || childElement.nodeType == Node.COMMENT_NODE ) {
+				if ( typeof childElement.setAttribute === 'function' || childElement.nodeType === Node.COMMENT_NODE ) {
 					addAttributes( parentSection, childElement, previousParentElement, separatorElementAttributes, separatorSectionAttributes );
 				}
 			}
 		}
 
-		if ( element.nodeType == Node.COMMENT_NODE ) {
-			if ( addAttributeInElement( element, previousElement, separatorElementAttributes ) == false ) {
+		if ( element.nodeType === Node.COMMENT_NODE ) {
+			if ( addAttributeInElement( element, previousElement, separatorElementAttributes ) === false ) {
 				addAttributeInElement( element, section, separatorSectionAttributes );
 			}
 		}
@@ -380,14 +380,14 @@ const Plugin = () => {
 	 */
 	function convertSlides() {
 
-		var sections = deck.getRevealElement().querySelectorAll( '[data-markdown]:not([data-markdown-parsed])');
+		const sections = deck.getRevealElement().querySelectorAll( '[data-markdown]:not([data-markdown-parsed])');
 
 		[].slice.call( sections ).forEach( function( section ) {
 
 			section.setAttribute( 'data-markdown-parsed', true )
 
-			var notes = section.querySelector( 'aside.notes' );
-			var markdown = getMarkdownFromSlide( section );
+			const notes = section.querySelector( 'aside.notes' );
+			const markdown = getMarkdownFromSlide( section );
 
 			section.innerHTML = marked( markdown );
 			addAttributes( 	section, section, null, section.getAttribute( 'data-element-attributes' ) ||


### PR DESCRIPTION
While working with the markdown plugin, I've seen some semantic errors so fixed them. The changes are done in markdown plugin only.
The changes made in this PR:
- Refactored to replace `var` declarations with `let` or `const` for better variable management
- Refactored the code to replace `==` with `===` and `!=` with `!==` 