### PR TITLE
fix dracula li markers

### DIFF
--- a/css/theme/source/dracula.scss
+++ b/css/theme/source/dracula.scss
@@ -86,20 +86,17 @@ $codeFont: "Fira Code", $systemFontsMono;
 	--r-list-bullet-color: #{$listBulletColor};
 }
 
-.reveal strong, .reveal b {
-	color: var(--r-bold-color);
-}
-
-.reveal em, .reveal i, .reveal blockquote {
-	color: var(--r-italic-color);
-}
-
-.reveal code {
-	color: var(--r-inline-code-color);
-}
-
-// Dracula colored list bullets and numbers
 .reveal {
+	strong, b {
+		color: var(--r-bold-color);
+	}
+	em, i, blockquote {
+		color: var(--r-italic-color);
+	}
+	code {
+		color: var(--r-inline-code-color);
+	}
+	// Dracula colored list bullets and numbers
 	ul, ol {
 		li::marker {
 			color: var(--r-list-bullet-color);

--- a/css/theme/source/dracula.scss
+++ b/css/theme/source/dracula.scss
@@ -105,8 +105,5 @@ $codeFont: "Fira Code", $systemFontsMono;
 			color: var(--r-list-bullet-color);
 		}
 	}
-	ol {
-		counter-reset: li;
-	}
 }
 

--- a/css/theme/source/dracula.scss
+++ b/css/theme/source/dracula.scss
@@ -99,34 +99,14 @@ $codeFont: "Fira Code", $systemFontsMono;
 }
 
 // Dracula colored list bullets and numbers
-.reveal ul {
-	list-style: none;
+.reveal {
+	ul, ol {
+		li::marker {
+			color: var(--r-list-bullet-color);
+		}
+	}
+	ol {
+		counter-reset: li;
+	}
 }
 
-.reveal ul li::before {
-	content: "•";
-	color: var(--r-list-bullet-color);
-	display: inline-block;
-	width: 1em;
-	margin-left: -1em
-}
-
-.reveal ol {
-	list-style: none;
-	counter-reset: li;
-}
-
-.reveal ol li::before {
-	content: counter(li) ".";
-	color: var(--r-list-bullet-color);
-	display: inline-block;
-	width: 2em;
-
-	margin-left: -2.5em;
-    margin-right: 0.5em;
-	text-align: right;
-}
-
-.reveal ol li {
-	counter-increment: li
-}

--- a/dist/theme/dracula.css
+++ b/dist/theme/dracula.css
@@ -384,6 +384,3 @@ section.has-light-background, section.has-light-background h1, section.has-light
 .reveal ul li::marker, .reveal ol li::marker {
   color: var(--r-list-bullet-color);
 }
-.reveal ol {
-  counter-reset: li;
-}

--- a/dist/theme/dracula.css
+++ b/dist/theme/dracula.css
@@ -372,15 +372,12 @@ section.has-light-background, section.has-light-background h1, section.has-light
 .reveal strong, .reveal b {
   color: var(--r-bold-color);
 }
-
 .reveal em, .reveal i, .reveal blockquote {
   color: var(--r-italic-color);
 }
-
 .reveal code {
   color: var(--r-inline-code-color);
 }
-
 .reveal ul li::marker, .reveal ol li::marker {
   color: var(--r-list-bullet-color);
 }

--- a/dist/theme/dracula.css
+++ b/dist/theme/dracula.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * Dracula Dark theme for reveal.js.
  * Based on https://draculatheme.com
@@ -382,33 +381,9 @@ section.has-light-background, section.has-light-background h1, section.has-light
   color: var(--r-inline-code-color);
 }
 
-.reveal ul li {
-  list-style: none;
-}
-
-.reveal ul li::before {
-  content: "•";
+.reveal ul li::marker, .reveal ol li::marker {
   color: var(--r-list-bullet-color);
-  display: inline-block;
-  width: 1em;
-  margin-left: -1em;
 }
-
 .reveal ol {
-  list-style: none;
   counter-reset: li;
-}
-
-.reveal ol li::before {
-  content: counter(li) ".";
-  color: var(--r-list-bullet-color);
-  display: inline-block;
-  width: 2em;
-  margin-left: -2.5em;
-  margin-right: 0.5em;
-  text-align: right;
-}
-
-.reveal ol li {
-  counter-increment: li;
 }


### PR DESCRIPTION
when working on my presentation I noticed that `dracula.css` was modified because sass file hasn't been altered in #3450 (only the built css file has been edited)

At first this PR aimed only to simply apply the same patch to the sass file to make it match the compiled version, but then I noticed that dracula's way to render `<li>` marker was by adding `:before` pseudo elements resulting in always the same bullet point, whatever nesting level it was into (always a disc). In other themes, the li renders differently depending on the nesting level (disc, square, circle).

By replacing `:before` pseudo elements with `::marker` selector, we can have the same style as in other themes :
<img width="1047" alt="dracula-list-item-comparison" src="https://github.com/hakimel/reveal.js/assets/10920280/228d0084-c318-4afe-9776-113bb9b424ab">

from left to right : before this PR / PR / original "dark" theme for comparison

**NB:**  The bullets are now bigger than before this PR, but it is consistent with other themes. If one prefers smaller markers, it can be done in custom CSS : 
```css
.reveal ul li::marker {
    font-size: 70%; /* or whatever scale fits */
}
```