### PR TITLE
Notes plugin: notes from data-notes attribute were not shown

### DIFF
--- a/plugin/notes/plugin.js
+++ b/plugin/notes/plugin.js
@@ -146,7 +146,7 @@ const Plugin = () => {
 		}
 
 		// Look for notes defined in an aside element
-		if( notesElements ) {
+		if( notesElements && notesElements.length ) {
 			messageData.notes = Array.from(notesElements).map( notesElement => notesElement.innerHTML ).join( '\n' );
 			messageData.markdown = notesElements[0] && typeof notesElements[0].getAttribute( 'data-markdown' ) === 'string';
 		}


### PR DESCRIPTION
Fixes #3476 : `data-notes` worked on fragment level, but not at slide level