### PR TITLE
fix: use `setAttribute` instead of `innerHTML` to prevent XSS

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -142,13 +142,15 @@ export default class SlideContent {
 
 					// Support comma separated lists of video sources
 					backgroundVideo.split( ',' ).forEach( source => {
+						const sourceElement = document.createElement( 'source' );
+						sourceElement.setAttribute( 'src', source );
+
 						let type = getMimeTypeFromFile( source );
 						if( type ) {
-							video.innerHTML += `<source src="${source}" type="${type}">`;
+							sourceElement.setAttribute( 'type', type );
 						}
-						else {
-							video.innerHTML += `<source src="${source}">`;
-						}
+
+						video.appendChild( sourceElement );
 					} );
 
 					backgroundContent.appendChild( video );


### PR DESCRIPTION
> Fixed #3546 

Hi @hakimel 

Following our previous discussion, I have made changes to use `setAttribute` instead of `innerHTML` to prevent XSS vulnerabilities.

I have created two small demos for you to try. The first demonstrates an XSS issue caused by using `innerHTML`:

https://jsfiddle.net/EastSun5566/9cfxeLzv/14/

The second uses `setAttribute` for attribute assignment:

https://jsfiddle.net/EastSun5566/rbogezv1/8/

You will notice that in the first case, an alert is triggered, while in the second, it is not. Although I believe URLs should be sanitized before setting attributes, I think this solution is good enough now.

Please let me know your thoughts. Thank you!