### PR TITLE
codespell: add config + workflow and make it fix some typos it finds

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,package-lock.json,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,5 +2,7 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = .git*,package-lock.json,*.css,.codespellrc
 check-hidden = true
-# ignore-regex = 
+# Ignore super long lines -- must be minimized etc, acronyms
+# and some near hit variables
+ignore-regex = ^.{120,}|\b(currentY|FOM)\b
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/css/theme/template/exposer.scss
+++ b/css/theme/template/exposer.scss
@@ -1,4 +1,4 @@
-// Exposes theme's variables for easy re-use in CSS for plugin authors
+// Exposes theme's variables for easy reuse in CSS for plugin authors
 
 :root {
   --r-background-color: #{$backgroundColor};

--- a/js/controllers/jumptoslide.js
+++ b/js/controllers/jumptoslide.js
@@ -74,7 +74,7 @@ export default class JumpToSlide {
 		let query = this.jumpInput.value.trim( '' );
 		let indices;
 
-		// When slide numbers are formatted to be a single linear mumber
+		// When slide numbers are formatted to be a single linear number
 		// (instead of showing a separate horizontal/vertical index) we
 		// use the same format for slide jumps
 		if( /^\d+$/.test( query ) ) {

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -1252,7 +1252,7 @@ export default function( revealElement, options ) {
 
 	/**
 	 * Returns true if we're currently on the last slide in
-	 * the presenation. If the last slide is a stack, we only
+	 * the presentation. If the last slide is a stack, we only
 	 * consider this the last slide if it's at the end of the
 	 * stack.
 	 */

--- a/plugin/highlight/plugin.js
+++ b/plugin/highlight/plugin.js
@@ -52,7 +52,7 @@ const Plugin = {
 				block.innerHTML = betterTrim( block );
 			}
 
-			// Escape HTML tags unless the "data-noescape" attrbute is present
+			// Escape HTML tags unless the "data-noescape" attribute is present
 			if( config.escapeHTML && !block.hasAttribute( 'data-noescape' )) {
 				block.innerHTML = block.innerHTML.replace( /</g,"&lt;").replace(/>/g, '&gt;' );
 			}

--- a/plugin/notes/plugin.js
+++ b/plugin/notes/plugin.js
@@ -229,7 +229,7 @@ const Plugin = () => {
 					openSpeakerWindow();
 				}
 				else {
-					// Keep listening for speaker view hearbeats. If we receive a
+					// Keep listening for speaker view heartbeats. If we receive a
 					// heartbeat from an orphaned window, reconnect it. This ensures
 					// that we remain connected to the notes even if the presentation
 					// is reloaded.

--- a/plugin/zoom/plugin.js
+++ b/plugin/zoom/plugin.js
@@ -147,7 +147,7 @@ var zoom = (function(){
 	}
 
 	/**
-	 * Pan the document when the mosue cursor approaches the edges
+	 * Pan the document when the mouse cursor approaches the edges
 	 * of the window.
 	 */
 	function pan() {


### PR DESCRIPTION
Originally spotted in a "derived" project which bundled reveal.js files -- saw `presenation` and decided to act.

I fixed typos only in source files since I have configured overlong lines to be ignored. So it is still there:

```
❯ git grep -l presenation
dist/reveal.esm.js.map
dist/reveal.js.map
```
please advise if I should regenerate those or would be done automagically/later?