### PR TITLE
Fix escape before comma in regex is redundant

### DIFF
--- a/js/utils/color.js
+++ b/js/utils/color.js
@@ -44,7 +44,7 @@ export const colorToRgb = ( color ) => {
 		};
 	}
 
-	let rgba = color.match( /^rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\,\s*([\d]+|[\d]*.[\d]+)\s*\)$/i );
+	let rgba = color.match( /^rgba\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d]+|[\d]*.[\d]+)\s*\)$/i );
 	if( rgba ) {
 		return {
 			r: parseInt( rgba[1], 10 ),


### PR DESCRIPTION
There are various other commas in the same regex that aren't escaped.

This one doesn't need escaping either.