### PR TITLE
Fixing gulp package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -280,9 +280,8 @@ gulp.task('package', gulp.series(() =>
         [
             './index.html',
             './dist/**',
-            './lib/**',
-            './images/**',
             './plugin/**',
+            './slides/**',
             './**/*.md'
         ],
         { base: './' }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -284,7 +284,7 @@ gulp.task('package', gulp.series(() =>
             './slides/**',
             './**/*.md'
         ],
-        { base: './' }
+        { base: './', encoding: false }
     )
     .pipe(zip('reveal-js-presentation.zip')).pipe(gulp.dest('./'))
 


### PR DESCRIPTION
Fix #3692

- gulp: fixing the `package` task

    It was erroring with

    ```
    Error: ENOENT: no such file or directory, scandir 'reveal.js/lib'
    ```

- gulp package: fixing encoding after updating to gulp 5

    Took inspiration from this issue: https://github.com/sindresorhus/gulp-zip/issues/123