### PR TITLE
Add 'controlsOnlyForSpeaker' option

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -15,7 +15,9 @@ export default {
 	minScale: 0.2,
 	maxScale: 2.0,
 
-	// Display presentation control arrows
+	// Display presentation control arrows.
+	// This can be a boolean (true / false) or 'speaker-only' to only display
+	// the controls on the speaker's screen.
 	controls: true,
 
 	// Help the user learn the controls by providing hints, for example by

--- a/js/controllers/controls.js
+++ b/js/controllers/controls.js
@@ -66,7 +66,10 @@ export default class Controls {
 	 */
 	configure( config, oldConfig ) {
 
-		this.element.style.display = config.controls ? 'block' : 'none';
+		this.element.style.display = (
+			config.controls &&
+			(config.controls !== 'speaker-only' || this.Reveal.isSpeakerNotes())
+		) ? 'block' : 'none';
 
 		this.element.setAttribute( 'data-controls-layout', config.controlsLayout );
 		this.element.setAttribute( 'data-controls-back-arrows', config.controlsBackArrows );


### PR DESCRIPTION
Hi. Thanks for this great project.

This tiny PR adds a setting 'controlsOnlyForSpeaker' that only displays the controls for the presenter.