### PR TITLE
fix to prevent parent element of .reveal to collapse

### DIFF
--- a/css/reveal.scss
+++ b/css/reveal.scss
@@ -231,6 +231,10 @@ html.reveal-full-page {
 	position: relative;
 }
 
+*:has(> .reveal) {
+	height: 100%;
+}
+
 
 /*********************************************
  * CONTROLS


### PR DESCRIPTION
CSS selector will set height: 100% on parent element of .reveal div to avoid collapse. Fixes issue [3719](https://github.com/hakimel/reveal.js/issues/3719)