### PR TITLE
chore: ignoring node_modules in codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,package-lock.json,*.css,.codespellrc
+skip = .git*,node_modules,package-lock.json,*.css,.codespellrc
 check-hidden = true
 # Ignore super long lines -- must be minimized etc, acronyms
 # and some near hit variables


### PR DESCRIPTION
In some projects, when I use reveal.js, I get codespell issues in the `node_modules` folder, I think it's safe to ignore this folder from the analysis.