### PR TITLE
Update `display` config to support `!important` flag.

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -51,7 +51,13 @@ export default class SlideContent {
 	load( slide, options = {} ) {
 
 		// Show the slide element
-		slide.style.display = this.Reveal.getConfig().display;
+		const displayValue = this.Reveal.getConfig().display;
+		if( displayValue.includes('!important') ) {
+			const value = displayValue.replace(/\s*!important\s*$/, '').trim();
+			slide.style.setProperty('display', value, 'important');
+		} else {
+			slide.style.display = displayValue;
+		}
 
 		// Media elements with data-src attributes
 		queryAll( slide, 'img[data-src], video[data-src], audio[data-src], iframe[data-src]' ).forEach( element => {


### PR DESCRIPTION
The current implementation of the `display` config breaks if you attempt to set the display css to include the `!important` flag. This is because setting css properties though the style object does not support the flag, and the result is that no display property will be set on the slide.

This change adds support for the `!important` flag by using `style.setProperty` instead when the `display` config includes the `!important` flag.

I ran into this issue when using reveal.js with tailwind in a project. Upgrading from tailwind 3 to 4 introduced a breaking change that requires the `!important` flag on the slide display.