### PR TITLE
docs: fix missing semicolon in PHP snippet in markdown example

### DIFF
--- a/examples/markdown.html
+++ b/examples/markdown.html
@@ -93,7 +93,7 @@
                         {
                             $foo = array(
                                 'bar' => 'bar'
-                            )
+                            );
                         }
                         ```
                     </script>


### PR DESCRIPTION
Added missing semicolon in PHP array snippet in `examples/markdown.html`.
This makes the code snippet valid PHP.
