### PR TITLE
Fix: Remove bullet points from markdown task list items which includes checkboxes

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -130,6 +130,10 @@
 	list-style-type: circle;
 }
 
+.reveal li:has(> input[type="checkbox"]) {
+	list-style: none;
+}
+
 .reveal ul ul,
 .reveal ul ol,
 .reveal ol ol,


### PR DESCRIPTION
## Summary
Fixes issue addressed in #3826 where markdown task list items were displaying both bullet points and checkboxes in presentation view.
## Changes Made
- Added CSS rule `.reveal li:has(> input[type="checkbox"]) { list-style: none; }` to remove bullet points from task list items
- Applied the fix to the main theme template (`css/theme/template/theme.scss`) 
## Before/After
**Before:** Task list items showed both bullets (•) and checkboxes
**Screenshot**
<img width="1824" height="760" alt="image" src="https://github.com/user-attachments/assets/b19d8518-0bf4-4970-8729-c902368120d2" />

**After:** Task list items show only checkboxes, no bullets
**Screenshot**
<img width="869" height="331" alt="image" src="https://github.com/user-attachments/assets/a3085544-62bc-4e42-a6ee-a2edd7eb7f0e" />

## Technical Details
- Uses the `:has()` pseudo-class to target `<li>` elements that contain checkbox inputs
- The selector `li:has(> input[type="checkbox"])` ensures only direct child checkboxes are affected
- Maintains compatibility across all reveal.js themes
## Tests Performed
- [x] Verified fix works in multiple themes
- [x] Tested with both checked `[x]` and unchecked `[ ]` task items