### PR TITLE
Add data URI support for background video and video lightbox

### DIFF
--- a/js/controllers/overlay.js
+++ b/js/controllers/overlay.js
@@ -169,7 +169,20 @@ export default class Overlay {
 			video.loop = this.dom.dataset.previewLoop === 'true' ? true : false;
 			video.muted = this.dom.dataset.previewMuted === 'true' ? true : false;
 			video.playsInline = true;
-			video.src = url;
+
+			// Setting video.src with a data URI fails in some browsers
+			// because they can't infer the codec without a MIME type hint.
+			// A <source> element lets us provide an explicit type attribute.
+			if( /^data:([^;,]+)/.test( url.trim() ) ) {
+				const source = document.createElement( 'source' );
+				source.src = url;
+				source.type = RegExp.$1;
+				video.appendChild( source );
+			}
+			else {
+				video.src = url;
+			}
+
 			contentElement.appendChild( video );
 
 			video.addEventListener( 'loadeddata', () => {

--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -179,12 +179,20 @@ export default class SlideContent {
 						video.setAttribute( 'playsinline', '' );
 					}
 
-					// Support comma separated lists of video sources
-					backgroundVideo.split( ',' ).forEach( source => {
-						const sourceElement = document.createElement( 'source' );
-						sourceElement.setAttribute( 'src', source );
+					// Support comma separated lists of video sources, but
+					// treat data URIs as a single source since they contain commas
+					const videoSources = /^data:/.test( backgroundVideo.trim() )
+						? [backgroundVideo.trim()]
+						: backgroundVideo.split( ',' );
 
-						let type = getMimeTypeFromFile( source );
+					videoSources.forEach( source => {
+						const sourceElement = document.createElement( 'source' );
+						sourceElement.setAttribute( 'src', source.trim() );
+
+						// Extract MIME type from data URI, or fall back to file extension
+						let type = /^data:([^;,]+)/.test( source.trim() )
+							? RegExp.$1
+							: getMimeTypeFromFile( source );
 						if( type ) {
 							sourceElement.setAttribute( 'type', type );
 						}

--- a/test/test.html
+++ b/test/test.html
@@ -391,6 +391,64 @@
 					Reveal.syncSlide( slide );
 				});
 
+				QUnit.test( 'Reveal.syncSlide with data URI background video', function( assert ) {
+					var slide = Reveal.getSlide( 3 );
+					var videoURI = 'data:video/mp4;base64,AAAB';
+
+					slide.setAttribute( 'data-background-video', videoURI );
+					Reveal.syncSlide( slide );
+
+					var backgroundContent = Reveal.getSlideBackground( slide )
+						.querySelector( '.slide-background-content' );
+					var sourceElement = backgroundContent.querySelector( 'video source' );
+
+					assert.ok( sourceElement, 'video source element is created' );
+					assert.strictEqual( sourceElement.getAttribute( 'src' ), videoURI, 'source src is the full data URI' );
+					assert.strictEqual( sourceElement.getAttribute( 'type' ), 'video/mp4', 'MIME type is extracted from data URI' );
+
+					slide.removeAttribute( 'data-background-video' );
+					Reveal.syncSlide( slide );
+				});
+
+				QUnit.test( 'Reveal.syncSlide with comma-separated background videos', function( assert ) {
+					var slide = Reveal.getSlide( 3 );
+
+					slide.setAttribute( 'data-background-video', 'a.mp4,b.webm' );
+					Reveal.syncSlide( slide );
+
+					var backgroundContent = Reveal.getSlideBackground( slide )
+						.querySelector( '.slide-background-content' );
+					var sourceElements = backgroundContent.querySelectorAll( 'video source' );
+
+					assert.strictEqual( sourceElements.length, 2, 'comma-separated list produces two source elements' );
+					assert.strictEqual( sourceElements[0].getAttribute( 'src' ), 'a.mp4', 'first source src is correct' );
+					assert.strictEqual( sourceElements[1].getAttribute( 'src' ), 'b.webm', 'second source src is correct' );
+
+					slide.removeAttribute( 'data-background-video' );
+					Reveal.syncSlide( slide );
+				});
+
+				QUnit.test( 'Reveal.previewVideo with data URI', function( assert ) {
+					var videoURI = 'data:video/mp4;base64,AAAB';
+
+					Reveal.hidePreview();
+					Reveal.previewVideo( videoURI );
+
+					assert.ok( Reveal.isOverlayOpen(), 'overlay is open' );
+
+					var overlay = document.querySelector( '.reveal .r-overlay.r-overlay-preview' );
+					var video = overlay.querySelector( 'video' );
+					assert.ok( video, 'video element exists in overlay' );
+
+					var source = video.querySelector( 'source' );
+					assert.ok( source, 'source element is used instead of video.src' );
+					assert.strictEqual( source.src, videoURI, 'source src is the full data URI' );
+					assert.strictEqual( source.type, 'video/mp4', 'MIME type is extracted from data URI' );
+					assert.notOk( video.getAttribute( 'src' ), 'video.src is not set directly' );
+
+					Reveal.hidePreview();
+				});
+
 				QUnit.test( 'Reveal.syncFragments', function( assert ) {
 					var slide = Reveal.getSlide( 0 );
 					var fragmentA = document.createElement( 'span' );


### PR DESCRIPTION
# Add data URI support for background video and video lightbox

Fixes https://github.com/hakimel/reveal.js/issues/2469

## Problem

Reveal.js does not support `data:` URIs for video in two places:

### 1. `data-background-video`

The background video code splits the attribute value on `,` to support comma-separated source lists:

```js
backgroundVideo.split( ',' ).forEach( source => { ... } );
```

Data URIs contain commas (`data:video/mp4;base64,AAAB...`), so this split destroys the URI. Additionally, `getMimeTypeFromFile()` derives the MIME type from the file extension, which data URIs don't have.

For comparison, `data-background-image` already handles data URIs correctly by checking for the `data:` prefix before splitting (see `slidecontent.js` line ~153).

### 2. `previewMedia()` video lightbox

The media preview lightbox sets `video.src` directly:

```js
video.src = url;
```

Without a `type` attribute, the browser must sniff the video format from the binary data alone. This fails for data URIs in some browsers because they rely on the MIME type hint to select the correct decoder. Using a `<source>` element instead lets us provide an explicit `type` attribute.

## Solution

### Fix 1: `js/controllers/slidecontent.js`

Skip the comma split when the value is a data URI, and extract the MIME type from the URI itself:

```js
const videoSources = /^data:/.test( backgroundVideo.trim() )
    ? [backgroundVideo.trim()]
    : backgroundVideo.split( ',' );

videoSources.forEach( source => {
    const sourceElement = document.createElement( 'source' );
    sourceElement.setAttribute( 'src', source.trim() );

    let type = /^data:([^;,]+)/.test( source.trim() )
        ? RegExp.$1
        : getMimeTypeFromFile( source );
    ...
} );
```

### Fix 2: `js/controllers/overlay.js`

For data URI videos, use a `<source>` child element with the MIME type extracted from the URI, instead of setting `video.src` directly:

```js
if( /^data:([^;,]+)/.test( url.trim() ) ) {
    const source = document.createElement( 'source' );
    source.src = url;
    source.type = RegExp.$1;
    video.appendChild( source );
}
else {
    video.src = url;
}
```

## Use case

Build tools that produce self-contained single-file HTML presentations embed media assets as base64 data URIs. While embedding video does increase the HTML file size significantly, the trade-off is worthwhile — a single file is far easier to distribute, archive, and open than a folder of loose assets. This already works for images (which have data URI handling) but fails for videos without this fix.

## Live demo

https://mrduguo.github.io/reveal.js/