### PR TITLE
Support `string` for `transition`/`backgroundTransition`

### DIFF
--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -3,7 +3,7 @@
  *
  * @see {@link https://revealjs.com/transitions/}
  */
-type TransitionStyle = 'none' | 'fade' | 'slide' | 'convex' | 'concave' | 'zoom';
+type TransitionStyle = 'none' | 'fade' | 'slide' | 'convex' | 'concave' | 'zoom' | (string & {});
 /**
  * Slide transition speeds.
  *

--- a/js/config.ts
+++ b/js/config.ts
@@ -3,7 +3,7 @@
  *
  * @see {@link https://revealjs.com/transitions/}
  */
-type TransitionStyle = 'none' | 'fade' | 'slide' | 'convex' | 'concave' | 'zoom';
+type TransitionStyle = 'none' | 'fade' | 'slide' | 'convex' | 'concave' | 'zoom' | (string & {});
 
 /**
  * Slide transition speeds.


### PR DESCRIPTION
When implementing custom transitions in css I am passing a custom name here, which does go through to the class.

So I think it makes sense to support `string` in the types?

The `& {}` is so that autocomplete still works for the other options