### PR TITLE
Clone stack section headers into sub-slides for print-pdf view

### DIFF
--- a/js/controllers/printview.js
+++ b/js/controllers/printview.js
@@ -68,6 +68,29 @@ export default class PrintView {
 		const pageContainer = slides[0].parentNode;
 		let slideNumber = 1;
 
+		// Clone direct non-section children of stack sections into
+		// every child section so they appear on each sub-slide page
+		slides.forEach( function( slide ) {
+			if( slide.classList.contains( 'stack' ) ) {
+				const childSections = slide.querySelectorAll( ':scope > section' );
+				if( childSections.length === 0 ) return;
+
+				const nonSectionChildren = Array.from( slide.childNodes ).filter( child => {
+					if( child.nodeType === Node.ELEMENT_NODE && child.nodeName === 'SECTION' ) return false;
+					if( child.nodeType === Node.TEXT_NODE && !child.textContent.trim() ) return false;
+					return true;
+				} );
+
+				childSections.forEach( function( section ) {
+					for( let i = nonSectionChildren.length - 1; i >= 0; i-- ) {
+						section.insertBefore( nonSectionChildren[i].cloneNode( true ), section.firstChild );
+					}
+				} );
+
+				nonSectionChildren.forEach( child => child.remove() );
+			}
+		} );
+
 		// Slide and slide background layout
 		slides.forEach( function( slide, index ) {
 

--- a/test/test-pdf.html
+++ b/test/test-pdf.html
@@ -33,6 +33,19 @@
 					</section>
 				</section>
 
+				<section id="stack-with-header">
+					<h4>Stack Header</h4>
+					<section>
+						<p>Sub-slide 1</p>
+					</section>
+					<section>
+						<p>Sub-slide 2</p>
+					</section>
+					<section>
+						<p>Sub-slide 3</p>
+					</section>
+				</section>
+
 				<section id="fragment-slides">
 					<section>
 						<h1>3.1</h1>
@@ -78,15 +91,33 @@
 			QUnit.config.testTimeout = 30000;
 			QUnit.config.autostart = false;
 
-			Reveal.initialize({ pdf: true }).then( function() {
+			Reveal.initialize({ view: 'print' }).then( function() {
+
+				return new Promise( function( resolve ) {
+					Reveal.on( 'pdf-ready', resolve );
+				});
+			}).then( function() {
 
 				QUnit.start();
 
-				// Only one test for now, we're mainly ensuring that there
-				// are no execution errors when running PDF mode
-
 				QUnit.test( 'Reveal.isReady', function( assert ) {
 					assert.strictEqual( Reveal.isReady(), true, 'returns true' );
+				});
+
+				QUnit.test( 'Stack header is cloned into each sub-slide page', function( assert ) {
+					var pages = document.querySelectorAll( '.pdf-page' );
+					var stackPages = Array.from( pages ).filter( function( page ) {
+						return page.querySelector( 'p' ) &&
+							/Sub-slide \d/.test( page.querySelector( 'p' ).textContent );
+					});
+
+					assert.strictEqual( stackPages.length, 3, 'three pages created for stack sub-slides' );
+
+					stackPages.forEach( function( page, i ) {
+						var header = page.querySelector( 'h4' );
+						assert.ok( header, 'page ' + (i + 1) + ' contains the stack header' );
+						assert.strictEqual( header.textContent, 'Stack Header', 'page ' + (i + 1) + ' header text matches' );
+					});
 				});
 
 			} );


### PR DESCRIPTION
## Problem

When using `?print-pdf`, direct content inside a vertical stack section (content placed before the nested `<section>` elements) bleeds through at the top of the first page and does not appear on any sub-slide page.

Given this markup:

```html
<section>
    <h4>Timezone in Python</h4>

    <section>
        <h4><code>datetime</code> object</h4>
        <!-- ... -->
    </section>
    <section>
        <h4><code>zoneinfo</code></h4>
        <!-- ... -->
    </section>
</section>
```

The outer `<section>` gets the `.stack` class at runtime. In print-pdf mode, `printview.js` skips `.stack` elements — only child `<section>` elements are wrapped in `.pdf-page` divs. The `<h4>Timezone in Python</h4>` remains in the stack container, rendering as a stray heading at the top of the output.

## Solution

Before building PDF pages, iterate over stack sections and clone their direct non-section children into every child `<section>`. The originals are then removed from the stack container.

This makes the stack header appear at the top of each sub-slide page in the PDF output, acting as a repeating section title.

## Changes

- **`js/controllers/printview.js`** — Added a pre-processing pass that clones non-section children of `.stack` sections into each child section.
- **`test/test-pdf.html`** — Added a `stack-with-header` fixture, switched init config from the no-op `{ pdf: true }` to `{ view: 'print' }` (which actually activates print view), added a wait for the `pdf-ready` event, and added assertions verifying the header is present in all sub-slide pages.
