### PR TITLE
feat(markdown): add configurable loader for external markdown

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -148,6 +148,7 @@ interface MarkdownConfig {
 	verticalSeparator?: string;
 	notesSeparator?: string;
 	attributes?: string;
+	loader?: ( ref: string, section: HTMLElement ) => string | Promise<string>;
 }
 
 /**

--- a/plugin/markdown/plugin.js
+++ b/plugin/markdown/plugin.js
@@ -220,8 +220,8 @@ const Plugin = () => {
 					externalPromises.push( loadExternalMarkdown( section ).then(
 
 						// Finished loading external file
-						function( xhr, url ) {
-							section.outerHTML = slidify( xhr.responseText, {
+						function( markdown ) {
+							section.outerHTML = slidify( markdown, {
 								separator: section.getAttribute( 'data-separator' ),
 								verticalSeparator: section.getAttribute( 'data-separator-vertical' ),
 								notesSeparator: section.getAttribute( 'data-separator-notes' ),
@@ -230,9 +230,10 @@ const Plugin = () => {
 						},
 
 						// Failed to load markdown
-						function( xhr, url ) {
+						function( error ) {
+							const ref = section.getAttribute( 'data-markdown' );
 							section.outerHTML = '<section data-state="alert">' +
-								'ERROR: The attempt to fetch ' + url + ' failed with HTTP status ' + xhr.status + '.' +
+								'ERROR: The attempt to fetch ' + ref + ' failed with ' + ( error?.message || String( error ) ) + '.' +
 								'Check your browser\'s JavaScript console for more details.' +
 								'<p>Remember that you need to serve the presentation HTML from a HTTP server.</p>' +
 								'</section>';
@@ -260,13 +261,15 @@ const Plugin = () => {
 
 	}
 
-	function loadExternalMarkdown( section ) {
+	/**
+	 * Default XHR-based markdown loader. Resolves with the file
+	 * contents as a string, rejects with an Error on failure.
+	 */
+	function defaultMarkdownLoader( ref, section ) {
 
 		return new Promise( function( resolve, reject ) {
 
-			const xhr = new XMLHttpRequest(),
-				url = section.getAttribute( 'data-markdown' );
-
+			const xhr = new XMLHttpRequest();
 			const datacharset = section.getAttribute( 'data-charset' );
 
 			// see https://developer.mozilla.org/en-US/docs/Web/API/element.getAttribute#Notes
@@ -274,32 +277,47 @@ const Plugin = () => {
 				xhr.overrideMimeType( 'text/html; charset=' + datacharset );
 			}
 
-			xhr.onreadystatechange = function( section, xhr ) {
+			xhr.onreadystatechange = function() {
 				if( xhr.readyState === 4 ) {
 					// file protocol yields status code 0 (useful for local debug, mobile applications etc.)
 					if ( ( xhr.status >= 200 && xhr.status < 300 ) || xhr.status === 0 ) {
 
-						resolve( xhr, url );
+						resolve( xhr.responseText );
 
 					}
 					else {
 
-						reject( xhr, url );
+						reject( new Error( 'HTTP status ' + xhr.status ) );
 
 					}
 				}
-			}.bind( this, section, xhr );
+			};
 
-			xhr.open( 'GET', url, true );
+			xhr.open( 'GET', ref, true );
 
 			try {
 				xhr.send();
 			}
 			catch ( e ) {
-				console.warn( 'Failed to get the Markdown file ' + url + '. Make sure that the presentation and the file are served by a HTTP server and the file can be found there. ' + e );
-				resolve( xhr, url );
+				console.warn( 'Failed to get the Markdown file ' + ref + '. Make sure that the presentation and the file are served by a HTTP server and the file can be found there. ' + e );
+				resolve( xhr.responseText );
 			}
 
+		} );
+
+	}
+
+	/**
+	 * Loads markdown for a section, dispatching to the user-configured
+	 * `markdown.loader` if set, otherwise to defaultMarkdownLoader.
+	 */
+	function loadExternalMarkdown( section ) {
+
+		const ref = section.getAttribute( 'data-markdown' );
+		const loader = deck?.getConfig?.().markdown?.loader || defaultMarkdownLoader;
+
+		return new Promise( function( resolve ) {
+			resolve( loader( ref, section ) );
 		} );
 
 	}

--- a/test/test-markdown.html
+++ b/test/test-markdown.html
@@ -310,6 +310,18 @@
 			</div>
 		</div>
 
+		<div class="reveal deck7" style="display: none;">
+			<div class="slides">
+				<section data-markdown="simple.md" data-separator="^---$"></section>
+			</div>
+		</div>
+
+		<div class="reveal deck8" style="display: none;">
+			<div class="slides">
+				<section data-markdown="simple.md"></section>
+			</div>
+		</div>
+
 		<script type="module">
 			import 'reveal.css';
 			import 'qunit/qunit/qunit.css';
@@ -503,12 +515,53 @@
 
 			} );
 
+			let deck7 = new Reveal( document.querySelector( '.deck7' ), {
+				markdown: {
+					loader: function( ref, section ) {
+						return '## Custom A\n---\n## Custom B\n---\n## Custom C';
+					}
+				},
+				plugins: [ Markdown ]
+			})
+			deck7.addEventListener( 'ready', function() {
+
+				QUnit.module( 'Custom Loader' );
+
+				QUnit.test( 'Loader overrides default external fetch', function( assert ) {
+					assert.strictEqual( deck7.getRevealElement().querySelectorAll( '.reveal .slides>section' ).length, 3, 'found three slides from custom loader content' );
+				});
+
+			} );
+
+			let deck8 = new Reveal( document.querySelector( '.deck8' ), {
+				markdown: {
+					loader: function( ref, section ) {
+						throw new Error( 'boom' );
+					}
+				},
+				plugins: [ Markdown ]
+			})
+			deck8.addEventListener( 'ready', function() {
+
+				QUnit.module( 'Custom Loader Errors' );
+
+				QUnit.test( 'Loader synchronous throw is rendered as alert section', function( assert ) {
+					const alerts = deck8.getRevealElement().querySelectorAll( '.reveal .slides>section[data-state="alert"]' );
+					assert.strictEqual( alerts.length, 1, 'found one alert section' );
+					assert.ok( alerts[0].textContent.indexOf( 'boom' ) !== -1, 'alert section mentions error message' );
+					assert.ok( alerts[0].textContent.indexOf( 'simple.md' ) !== -1, 'alert section mentions ref' );
+				});
+
+			} );
+
 			deck1.initialize();
 			deck2.initialize();
 			deck3.initialize();
 			deck4.initialize();
 			deck5.initialize();
 			deck6.initialize();
+			deck7.initialize();
+			deck8.initialize();
 		</script>
 
 	</body>


### PR DESCRIPTION
Adds an optional `markdown.loader` config that overrides the default XHR fetch for `data-markdown` references. Useful for authenticated storage, virtual references, or custom resolution relative to the surrounding document.

The default XHR path is preserved unchanged, including the `status === 0` fallback for `file://` sources. Tests cover the override (deck 7) and synchronous loader throws rendering as alert sections (deck 8).

Also fixes a latent bug where the error alert showed `undefined` instead of the failing reference: the `url` argument in `resolve(xhr, url)` / `reject(xhr, url)` was silently dropped, since Promise callbacks only receive the first resolution value.
