### PR TITLE
Make adjacent `<ul>` + `<ol>` renders inline instead of stacked

### DIFF
--- a/css/theme/template/theme.scss
+++ b/css/theme/template/theme.scss
@@ -143,6 +143,13 @@
 	margin-left: 40px;
 }
 
+.reveal ul + ul,
+.reveal ul + ol,
+.reveal ol + ul,
+.reveal ol + ol {
+	display: block;
+}
+
 .reveal dt {
 	font-weight: bold;
 }


### PR DESCRIPTION
When a `<ul>` is immediately followed by a `<ol>` as siblings inside a slide, the ordered list flows inline with the unordered list — the `<ol>` items get appended to the last `<ul>` item on the same line. Adding any block-level element (e.g. a `<p>`) between them fixes it.

<img width="337" height="313" alt="Screenshot 2026-05-16 at 9 58 13 AM" src="https://github.com/user-attachments/assets/0f652283-07c4-4359-8f1a-1e31e100981e" />


```html
<!DOCTYPE html>
<html>
<head>
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reset.css">
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.css">
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/theme/white.css">
</head>
<body>
  <div class="reveal">
    <div class="slides">
      <section>
        <h2>Bug: nothing between</h2>
        <ul>
          <li>Bullet one</li>
          <li>Bullet two</li>
        </ul>
        <ol>
          <li>Ordered one</li>
          <li>Ordered two</li>
        </ol>
      </section>
      <section>
        <h2>Works: paragraph between</h2>
        <ul>
          <li>Bullet one</li>
          <li>Bullet two</li>
        </ul>
        <p>hello</p>
        <ol>
          <li>Ordered one</li>
          <li>Ordered two</li>
        </ol>
      </section>
    </div>
  </div>
  <script src="https://cdn.jsdelivr.net/npm/reveal.js@5/dist/reveal.js"></script>
  <script>Reveal.initialize();</script>
</body>
</html>
```

The cause is `css/theme/template/theme.scss` setting `display: inline-block` on top-level lists:

```scss
.reveal ol,
.reveal dl,
.reveal ul {
  display: inline-block;
  text-align: left;
  margin: 0 0 0 1em;
}
```

Because both `<ul>` and `<ol>` are `inline-block`, they flow inline when adjacent with no block element between them. Nested lists aren't affected since `.reveal ul ul, .reveal ul ol` etc. already override to `display: block` — but that doesn't cover sibling top-level lists.

This PR fixes that by adding 

```scss
.reveal ul + ol,
.reveal ol + ul,
.reveal ul + ul,
.reveal ol + ol {
  display: block;
}
```