### PR TITLE
fix(progress): don't add fragment progress on the last slide

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -2049,8 +2049,12 @@ export default function( revealElement, options ) {
 				// that is made up by its fragments (0-1)
 				let fragmentWeight = 0.9;
 
-				// Add fragment progress to the past slide count
-				pastCount += ( visibleFragments.length / allFragments.length ) * fragmentWeight;
+				// Only add fragment progress when not on the last slide.
+				// On the last slide, fragments should not increase pastCount
+				// beyond totalCount-1, as that would make progress > 1.
+				if( pastCount < totalCount - 1 ) {
+					pastCount += ( visibleFragments.length / allFragments.length ) * fragmentWeight;
+				}
 			}
 
 		}


### PR DESCRIPTION
Fixes #1980.

When fragments are used on the last slide, the fragment progress was added to `pastCount` which already equals `totalCount - 1`, making the result > 1 and causing the progress bar to overflow.

Fix by only adding fragment progress when `pastCount < totalCount - 1`, i.e., when not on the last slide. On the last slide, fragments should not increase the progress beyond 100%.