### PR TITLE
fix: add missing picocolors dependency and fix test script - I would be glad to become your contributor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,31 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2111,8 +2136,7 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
 			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/diff": {
 			"version": "8.0.3",
@@ -2181,7 +2205,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -3130,7 +3153,6 @@
 			"integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -3766,7 +3788,6 @@
 			"integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.1.5",
@@ -4078,7 +4099,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -4119,7 +4139,6 @@
 			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"url": "git://github.com/hakimel/reveal.js.git"
 	},
 	"devEngines": {
-		"runtime": {
+	"runtime": {
 			"name": "node",
 			"version": ">=20.19.0",
 			"onFail": "error"
@@ -110,6 +110,7 @@
 		"marked": "^17.0.5",
 		"marked-smartypants": "^1.1.11",
 		"node-qunit-puppeteer": "^2.2.1",
+		"picocolors": "^1.1.1",
 		"qunit": "^2.25.0",
 		"sass": "^1.98.0",
 		"typescript": "^6.0.2",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'path';
 import { glob } from 'glob';
 import { runQunitPuppeteer, printFailedTests } from 'node-qunit-puppeteer';
 import { createServer } from 'vite';
+import { red, green } from 'picocolors';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -51,16 +52,16 @@ const runTests = async (baseUrl) => {
 
 				if (result.stats.failed > 0) {
 					console.log(
-						`${'!'} ${file} [${result.stats.passed}/${result.stats.total}] in ${
+						red(`${'!'} ${file} [${result.stats.passed}/${result.stats.total}] in ${
 							result.stats.runtime
-						}ms`.red
+						}ms`)
 					);
 					printFailedTests(result, console);
 				} else {
 					console.log(
-						`${'✔'} ${file} [${result.stats.passed}/${result.stats.total}] in ${
+						green(`${'✔'} ${file} [${result.stats.passed}/${result.stats.total}] in ${
 							result.stats.runtime
-						}ms`.green
+						}ms`)
 					);
 				}
 			} catch (error) {


### PR DESCRIPTION
### Summary of changes

- Added `picocolors` to `devDependencies` in `package.json`.
- Refactored `scripts/test.js` to use `picocolors` instead of extending `String.prototype` with a non-existent `colors` package, which was causing runtime errors.

### Rationale

The `scripts/test.js` file was attempting to call `.red` and `.green` methods on strings, which are typically added by the `colors` package. However, this package was missing from `dependencies`/`devDependencies`, leading to `TypeError` failures during test execution. `picocolors` is a more lightweight, modern, and widely used alternative, already present in other workspaces within this project.

### Technical impact analysis

- Fixes the broken test suite infrastructure.
- Ensures that test execution correctly reports results with proper console coloring.
- Improves the maintainability of the testing script by replacing the side-effect-heavy `colors` package with explicit `picocolors` imports.