### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
CVE Lite CLI is an OWASP Lab Project that scans JS/TS lockfiles directly for vulnerable dependencies, without installing packages. Running it against reveal.js found 4 vulnerabilities across 313 packages in the dependency tree - including 2 high severity findings (vite@8.0.8 with a known advisory, and ws@8.20.1 reachable via puppeteer-core).

This adds a weekly scheduled scan on Mondays plus checks on every push and pull request against master. The scan fails the workflow on any high or critical severity finding, keeping the dependency tree clean over time. Findings are uploaded to GitHub Code Scanning via SARIF for inline annotations on PRs.

The workflow uses pinned commit SHA refs for all actions and reads the lockfile directly, so nothing is installed during the scan.

More details at [owasp.org/cve-lite-cli](https://owasp.org/cve-lite-cli)
