### PR TITLE
fix: always mute video overlays in speaker notes

### DIFF
--- a/js/controllers/overlay.js
+++ b/js/controllers/overlay.js
@@ -167,7 +167,7 @@ export default class Overlay {
 			video.autoplay = this.dom.dataset.previewAutoplay === 'false' ? false : true;
 			video.controls = this.dom.dataset.previewControls === 'false' ? false : true;
 			video.loop = this.dom.dataset.previewLoop === 'true' ? true : false;
-			video.muted = this.dom.dataset.previewMuted === 'true' ? true : false;
+			video.muted = this.Reveal.isSpeakerNotes() || this.dom.dataset.previewMuted === 'true';
 			video.playsInline = true;
 			video.src = url;
 			contentElement.appendChild( video );


### PR DESCRIPTION
To reproduce this bug, you may need to interact with the Speaker Notes window first (eg, click to reset the timer), or else your browser might block autoplaying video in the notes window.