### PR TITLE
Re-fit r-fit-text after web fonts load

### DIFF
--- a/js/controllers/slidecontent.js
+++ b/js/controllers/slidecontent.js
@@ -241,12 +241,19 @@ export default class SlideContent {
 		// size of its container. This needs to happen after the
 		// slide is visible in order to measure the text.
 		Array.from( scopeElement.querySelectorAll( '.r-fit-text' ) ).forEach( element => {
-			fitty( element, {
+			let fitter = fitty( element, {
 				minSize: 24,
 				maxSize: this.Reveal.getConfig().height * 0.8,
 				observeMutations: false,
 				observeWindow: false
 			} );
+
+			// Web fonts may finish loading after this initial fit, which
+			// would leave the text sized against the fallback font. Re-fit
+			// once fonts are ready so the text fills its container.
+			if( document.fonts && document.fonts.status !== 'loaded' ) {
+				document.fonts.ready.then( () => fitter.fit() );
+			}
 		} );
 
 	}


### PR DESCRIPTION
# Re-fit `.r-fit-text` after web fonts load

`.r-fit-text` is fitted once, when its slide enters view distance, and never re-fitted (`observeMutations: false`, `observeWindow: false`). On a cold load that fit happens before web fonts are ready, so fitty measures the fallback font. When the real font swaps in, the text is left mis-sized, usually only filling part of the container width. It's intermittent because it races font loading, and a window resize fixes it.

Reveal does re-layout on the `window` `load` event, but that only re-sizes `.r-stretch`, never `.r-fit-text`. The ESM fitty build has no `fonts.ready` hook either, so nothing re-fits.

## Fix

Re-fit once fonts are ready, unless they're already loaded:

```js
let fitter = fitty( element, {
    minSize: 24,
    maxSize: this.Reveal.getConfig().height * 0.8,
    observeMutations: false,
    observeWindow: false
} );

if( document.fonts && document.fonts.status !== 'loaded' ) {
    document.fonts.ready.then( () => fitter.fit() );
}
```

Only runs when fonts are still pending, so warm loads are unchanged.
