### PR TITLE
fix(notes): navigate upcoming preview to an explicit target at stack boundaries

### DIFF
--- a/plugin/notes/speaker-view.html
+++ b/plugin/notes/speaker-view.html
@@ -510,7 +510,29 @@
 					// Update the note slides
 					currentSlide.contentWindow.postMessage( JSON.stringify({ method: 'setState', args: [ data.state ] }), '*' );
 					upcomingSlide.contentWindow.postMessage( JSON.stringify({ method: 'setState', args: [ upcomingState ] }), '*' );
-					upcomingSlide.contentWindow.postMessage( JSON.stringify({ method: 'next' }), '*' );
+
+					// The upcoming preview is a separate reveal.js instance and tracks
+					// its own vertical position per stack, which can differ from the
+					// main presentation. Compute the next destination from the main
+					// state and navigate with explicit indices instead of calling
+					// next() in the preview.
+					callRevealApi( 'availableFragments', [], function( fragments ) {
+						if( fragments && fragments.next ) {
+							upcomingSlide.contentWindow.postMessage( JSON.stringify({ method: 'next' }), '*' );
+							return;
+						}
+						callRevealApi( 'availableRoutes', [], function( routes ) {
+							if( routes.down ) {
+								upcomingSlide.contentWindow.postMessage( JSON.stringify({ method: 'slide', args: [ data.state.indexh, data.state.indexv + 1 ] }), '*' );
+							}
+							else {
+								callRevealApi( 'getConfig', [], function( config ) {
+									var upcomingIndexv = config.navigationMode === 'grid' ? data.state.indexv : 0;
+									upcomingSlide.contentWindow.postMessage( JSON.stringify({ method: 'slide', args: [ data.state.indexh + 1, upcomingIndexv ] }), '*' );
+								} );
+							}
+						} );
+					} );
 
 				}
 


### PR DESCRIPTION
# Fix speaker view upcoming preview at vertical stack boundaries

Fixes #3831

## The bug

On the last subslide of a vertical stack, the speaker view's Upcoming pane can show a subslide of the next stack instead of its first slide. It happens after navigating backwards at some point, so forward-only runs look fine.

(repro in #3831: A→B→C→X→Y, then back to C previews Y instead of X).

## Root cause

The Upcoming pane is a live reveal.js iframe that receives the presenter's state and then runs `next()` on itself. Since the preview is always one slide ahead, it visits stacks deeper than the presenter and stores those positions (`data-previous-indexv`) — inside the iframe. At a stack boundary, `next()` resolves to `slide( indexh + 1, undefined )`, which restores that stored position instead of landing on the stack's first slide.

## The fix

Resolve the preview target from the main window's state instead of calling `next()` in the preview:

- unrevealed fragments: still forward `next()` (stays on the current slide)
- down route available: `slide( indexh, indexv + 1 )`
- otherwise: `slide( indexh + 1, 0 )`, or `slide( indexh + 1, indexv )` with `navigationMode: 'grid'`

With explicit indices the preview's own navigation history is never consulted, so it always matches where the presenter will actually land.

## Testing

Verified manually with a two-stack deck: the #3831 sequence now previews the next stack's first slide, while forward-only runs, fragments and `navigationMode: 'grid'` behave as before.
