### PR TITLE
Fix configured slide numbers in PDF exports

### DIFF
--- a/js/controllers/printview.js
+++ b/js/controllers/printview.js
@@ -23,6 +23,7 @@ export default class PrintView {
 
 		// Compute slide numbers now, before we start duplicating slides
 		const injectPageNumbers = config.slideNumber && /all|print/i.test( config.showSlideNumber );
+		const slideNumbers = injectPageNumbers ? slides.map( slide => this.Reveal.slideNumber.getSlideNumber( slide ) ) : [];
 
 		const slideSize = this.Reveal.getComputedSlideSize( window.innerWidth, window.innerHeight );
 
@@ -66,7 +67,6 @@ export default class PrintView {
 
 		const pages = [];
 		const pageContainer = slides[0].parentNode;
-		let slideNumber = 1;
 
 		// Slide and slide background layout
 		slides.forEach( function( slide, index ) {
@@ -150,7 +150,7 @@ export default class PrintView {
 					const numberElement = document.createElement( 'div' );
 					numberElement.classList.add( 'slide-number' );
 					numberElement.classList.add( 'slide-number-pdf' );
-					numberElement.innerHTML = slideNumber++;
+					numberElement.innerHTML = slideNumbers[ index ];
 					page.appendChild( numberElement );
 				}
 

--- a/test/test-pdf.html
+++ b/test/test-pdf.html
@@ -78,7 +78,17 @@
 			QUnit.config.testTimeout = 30000;
 			QUnit.config.autostart = false;
 
-			Reveal.initialize({ pdf: true }).then( function() {
+			const pdfReady = new Promise( resolve => Reveal.on( 'pdf-ready', resolve ) );
+
+			Promise.all( [
+				Reveal.initialize({
+					view: 'print',
+					slideNumber: 'c/t',
+					showSlideNumber: 'print',
+					pdfSeparateFragments: false
+				}),
+				pdfReady
+			] ).then( function() {
 
 				QUnit.start();
 
@@ -87,6 +97,12 @@
 
 				QUnit.test( 'Reveal.isReady', function( assert ) {
 					assert.strictEqual( Reveal.isReady(), true, 'returns true' );
+				});
+
+				QUnit.test( 'configured slide number format', function( assert ) {
+					const slideNumbers = Array.from( document.querySelectorAll( '.slide-number-pdf' ) );
+					assert.strictEqual( slideNumbers.length, 8, 'creates a number for each slide' );
+					assert.strictEqual( slideNumbers[4].textContent.replace( /\s/g, '' ), '5/8', 'uses the configured c/t format' );
 				});
 
 			} );


### PR DESCRIPTION
## Summary

- Fixes: With slideNumber set to c/t, interactive slides render values such as 5 / 8 while print/PDF pages render only 5.
- Root cause: PrintView generated sequential integers after beginning PDF layout instead of using the existing SlideNumber formatter. Formatting must be computed before slides are moved into PDF page containers because the formatter derives current and total values from the original slide hierarchy.

## Regression evidence

- Before: `npm test` exited `1`

- After: `npm test` exited `0`

## Verification

- `npm test`
- `npm run build`
- `git diff --cached --check`

## Scope

- 2 files changed, +20 / -4 lines
