### PR TITLE
fix(markdown): allow attribute manipulation of lists

### DIFF
--- a/plugin/markdown/plugin.js
+++ b/plugin/markdown/plugin.js
@@ -370,12 +370,8 @@ const Plugin = () => {
 		}
 
 		if ( element.nodeType === Node.COMMENT_NODE ) {
-		let targetElement = previousElement;
-		if( targetElement && ( targetElement.tagName === 'UL' || targetElement.tagName === 'OL' ) ) {
-			targetElement = targetElement.lastElementChild || targetElement;
-		}
 
-		if ( addAttributeInElement( element, targetElement, separatorElementAttributes ) === false ) {
+		if ( addAttributeInElement( element, previousElement, separatorElementAttributes ) === false ) {
 				addAttributeInElement( element, section, separatorSectionAttributes );
 			}
 		}


### PR DESCRIPTION
Allow attribute manipulation of lists using `<!-- .element class="a-class" -->` syntax. Previously (since Reveal.js 6), attribute manipulation was applied to the last element of a list instead of the list itself.

Workaround for when you want the class on the last element:

```md
- html
- <!-- .element class="a-class" -->
  css
```

Fixes #3931